### PR TITLE
[YUNIKORN-419] Add helm package to release tool

### DIFF
--- a/helm-charts/yunikorn/Chart.yaml
+++ b/helm-charts/yunikorn/Chart.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 apiVersion: v1
-appVersion: "0.8.0"
+appVersion: "latest"
 description: YuniKorn scheduler for Kubernetes
 name: yunikorn
-version: 0.8.0
+version: latest


### PR DESCRIPTION
Documentation on how to release is missing information around packaging
and signing of the helm chart.
Add building the helm chart package to the release tool. Extend the
signing to include the helm package. Generate a digest (checksum) if
signing is not possible for updating the index file.

Add checks for the availability of gpg and helm tools on the path.