### PR TITLE
[YUNIKORN-435] Set service_account_name as env

### DIFF
--- a/helm-charts/yunikorn/templates/deployment.yaml
+++ b/helm-charts/yunikorn/templates/deployment.yaml
@@ -57,6 +57,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
             - name: ADMISSION_CONTROLLER_IMAGE_REGISTRY
               value: "{{ .Values.admission_controller_image.repository }}"
             - name: ADMISSION_CONTROLLER_IMAGE_TAG


### PR DESCRIPTION
Use the serviceAccountName from podSpec for admission controller pod.

Reference: https://issues.apache.org/jira/browse/YUNIKORN-435
