### PR TITLE
[YUNIKORN-451]Fix application CRD definition

### DIFF
--- a/helm-charts/yunikorn/templates/crds/application-definition.yaml
+++ b/helm-charts/yunikorn/templates/crds/application-definition.yaml
@@ -50,17 +50,60 @@ spec:
         spec:
           type: object
           properties:
-            minMember:
-              type: integer
+            schedulingPolicy:
+              type: object
+              properties:
+                type:
+                  type: string
+                parameters:
+                  type: object
+                  additionalProperties:
+                    type: string
             queue:
               type: string
               pattern: '^[a-zA-Z0-9_-]{1,64}([.]{1}[a-zA-Z0-9_-]{1,64})*$'
-            maxPendingSeconds:
-              type: integer
-              minimum: 1
+            taskGroups:
+              type: array
+              items:
+                type: object
+                properties:
+                  name: 
+                    type: string
+                  minMember:
+                    type: integer
+                  minResource:
+                    type: object
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: '^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$'
+                      x-kubernetes-int-or-string: true 
+                  nodeSelector:
+                    type: object
+                    additionalProperties:
+                      type: string
+                  tolerations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        effect:
+                          type: string
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        value:
+                          type: string
+                        tolerationSeconds:
+                          format: int64
+                          type: integer             
         status:
           type: object
           properties:
+            appID:
+              type: string
             appstatus:
               type: string
             message:


### PR DESCRIPTION
The application-definition.yaml in release and k8shim repo should be synchronous.
So the e2e test in [PR205](https://github.com/apache/incubator-yunikorn-k8shim/pull/205) will check schema with latest application-definition.yaml. 