### PR TITLE
[YUNIKORN-617] Update the copyright years in NOTICE file.

### DIFF
--- a/release-top-level-artifacts/NOTICE
+++ b/release-top-level-artifacts/NOTICE
@@ -1,5 +1,5 @@
 Apache YuniKorn (Incubating)
-Copyright 2019-2020 The Apache Software Foundation
+Copyright 2019-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
Currently, the NOTICE file in the release tarball has the following context: "Copyright 2019-2020 The Apache Software Foundation". According to https://www.apache.org/legal/src-headers.html#notice, we need to update the YEAR-YEAR to 2019-2021.