### PR TITLE
[YUNIKORN-759] Fix the helm install command in README 

### DIFF
--- a/helm-charts/yunikorn/README.md
+++ b/helm-charts/yunikorn/README.md
@@ -52,7 +52,7 @@ YuniKorn can be deployed with [helm-charts](https://hub.helm.sh/charts/yunikorn/
 ```
 helm repo add yunikorn  https://apache.github.io/incubator-yunikorn-release
 helm repo update 
-helm install yunikorn/yunikorn
+helm install yunikorn yunikorn/yunikorn
 ```
 ## Configuration
 The following table lists the configurable parameters of the YuniKorn chart and their default values.


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/YUNIKORN-759

Yunikorn page in Helm (https://artifacthub.io/packages/helm/yunikorn/yunikorn) offers a incorrect command: "helm install yunikorn/yunikorn"
The "Get Started" page suggests readers to check the page in Helm to see configuration options and hence it would be good to fix it.