### PR TITLE
[YUNIKORN-778] Add nodeSelector as configurable value in helm chart

### DIFF
--- a/helm-charts/yunikorn/README.md
+++ b/helm-charts/yunikorn/README.md
@@ -78,6 +78,7 @@ The following table lists the configurable parameters of the YuniKorn chart and 
 | `resources.limits.memory`         | Memory resource limit                                          | `2Gi` 
 | `embedAdmissionController`        | Flag for enabling/disabling the admission controller           | `true`
 | `operatorPlugins`                 | Scheduler operator plugins                                     | `general` 
+| `nodeSelector`                    | Scheduler deployment nodeSelector(s)                           | ` `      
 
 These parameters can be passed in via helm's `--set` option, such as `--set embedAdmissionController=false`.
 

--- a/helm-charts/yunikorn/templates/deployment.yaml
+++ b/helm-charts/yunikorn/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
       {{- end }}
       {{- end }}
       serviceAccountName: {{ .Values.serviceAccount }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: yunikorn-scheduler-k8s
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Issue: [YUNIKORN-778](https://issues.apache.org/jira/browse/YUNIKORN-778)

This PR adds a nodeSelector field to the deployment.yaml template. If there are nodeSelector fields defined in values.yaml, all key/value pairs will be added to the deployment template. For example:
```
resources:
  requests:
    cpu: 200m
    memory: 1Gi
  limits:
    cpu: 4
    memory: 2Gi

nodeSelector:
  kubernetes.io/hostname: worker-01
  beta.kubernetes.io/arch: amd64
```

This has been tested using 0-2 nodeSelector fields. An example deployment file generated by `helm template --debug` is attached: [deployment.yaml](https://github.com/apache/incubator-yunikorn-release/files/6927734/tmp.txt)
