### PR TITLE
[YUNIKORN-29] Add perf-tools to generate function/performance reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 staging/*
 staging/**
+target

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,36 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+module github.com/apache/incubator-yunikorn-release
+
+go 1.15
+
+require (
+	github.com/apache/incubator-yunikorn-core v0.0.0-20210130000555-5a1c19e280f6
+	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/mitchellh/mapstructure v1.1.2
+	github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+	github.com/TaoYang526/goutils v0.0.0-20210209083921-039008f0a57d
+	go.uber.org/zap v1.13.0
+	gonum.org/v1/plot v0.9.0
+	gopkg.in/yaml.v2 v2.2.8
+	gotest.tools v2.2.0+incompatible
+	k8s.io/api v0.20.11
+	k8s.io/apimachinery v0.20.11
+	k8s.io/client-go v0.20.11
+)

--- a/perf-tools/Makefile
+++ b/perf-tools/Makefile
@@ -1,0 +1,22 @@
+.PHONY: build clean
+
+TARGET_DIR ?= target
+BINARY_DIR ?= perf-tools-bin
+BINARY ?= perf-tools
+
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+
+build: clean
+	@mkdir ${TARGET_DIR}
+	@mkdir ${TARGET_DIR}/${BINARY_DIR}
+	@echo "[Action] mkdir target and bin directory"
+	@CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build -o ${TARGET_DIR}/${BINARY_DIR}/${BINARY} .
+	@echo "[Action] build binary"
+	@cp conf.yaml ${TARGET_DIR}/${BINARY_DIR}
+	@echo "[Action] copy binary and conf file to binary directory"
+	@tar -zcvf ${TARGET_DIR}/${BINARY_DIR}.tar.gz -C ${TARGET_DIR} ${BINARY_DIR}
+	@echo "[Action] generate binary package: ${TARGET_DIR}/${BINARY_DIR}.tar.gz"
+
+clean:
+	@if [ -d "${TARGET_DIR}" ] ; then rm -rf ${TARGET_DIR} && echo "[Action] cleaned target directory" ; fi

--- a/perf-tools/conf.yaml
+++ b/perf-tools/conf.yaml
@@ -1,0 +1,78 @@
+common:
+  kubeconfigfile: $HOME/.kube/config
+  schedulername: yunikorn
+  maxwaitseconds: 600
+  queue: root.default
+  namespace: default
+  outputrootpath: /tmp
+  podtemplatespec:
+    objectmeta:
+      annotations:
+        kubernetes.docker.network.type: HOST
+#  nodeselector: 'partition=blink-ut'
+  podspec:
+    hostnetwork: true
+    containers:
+      - name: curl-test
+        image: curlimages/curl
+        command: ['sh', '-c', 'sleep 3600']
+        imagepullpolicy: IfNotPresent
+#    nodeselector:
+#      partition: blink-ut
+    tolerations:
+      - key: "partition"
+        operator: "Equal"
+        value: "blink-ut"
+        effect: "NoSchedule"
+
+scenarios:
+  throughput:
+    schedulerNames:
+#      - yunikorn
+      - default-scheduler
+    showNumOfLastTasks: 0
+    cleanUpDelayMs: 0
+    cases:
+      - description: simple-case
+        requestConfigs:
+          - numPods: 50
+            repeat: 1
+            requestResources:
+              cpu: 100m
+              memory: 500Mi
+            limitResources:
+              cpu: 200m
+              memory: 1000Mi
+      - description: simple-case-2
+        requestConfigs:
+          - numPods: 50
+            repeat: 2
+            requestResources:
+              cpu: 100m
+              memory: 500Mi
+            limitResources:
+              cpu: 200m
+              memory: 1000Mi
+  e2e_perf:
+    showNumOfLastTasks: 3
+    cleanUpDelayMs: 0
+    cases:
+      - description: simple-case
+        schedulerName: default-scheduler
+        requestConfigs:
+          - numPods: 5
+            repeat: 2
+            requestResources:
+              cpu: 100m
+              memory: 500Mi
+            limitResources:
+              cpu: 200m
+              memory: 1000Mi
+  node_fairness:
+    schedulerNames:
+#      - yunikorn
+      - default-scheduler
+    cases:
+      - numPodsPerNode: 5
+        allocatePercentage: 80
+        resourceName: "cpu"

--- a/perf-tools/constants/constants.go
+++ b/perf-tools/constants/constants.go
@@ -1,0 +1,35 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package constants
+
+import "gonum.org/v1/plot/vg"
+
+const (
+
+	// constants for app manager
+	DefaultContainerName  = "ngnix"
+	DefaultContainerImage = "nginx:1.12"
+	LabelAppID            = "applicationId"
+	LabelQueue            = "queue"
+
+	// constants for chart
+	ChartWidth      = 6 * vg.Inch
+	ChartHeight     = 6 * vg.Inch
+	ChartFileSuffix = ".svg"
+)

--- a/perf-tools/framework/app_analyzer.go
+++ b/perf-tools/framework/app_analyzer.go
@@ -1,0 +1,129 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package framework
+
+import (
+	"math"
+	"sort"
+
+	"github.com/TaoYang526/goutils/pkg/profiling"
+	"github.com/apache/incubator-yunikorn-release/perf-tools/utils"
+	"go.uber.org/zap"
+)
+
+type AppAnalyzer struct {
+	appInfo *AppInfo
+}
+
+func NewAppAnalyzer(appInfo *AppInfo) *AppAnalyzer {
+	return &AppAnalyzer{appInfo: appInfo}
+}
+
+func (aa *AppAnalyzer) GetLastTasks(lastN int) []*TaskStatus {
+	taskStatusSlice := make([]*TaskStatus, len(aa.appInfo.TasksStatus))
+	i := 0
+	for _, taskStatus := range aa.appInfo.TasksStatus {
+		taskStatusSlice[i] = taskStatus
+		i++
+	}
+	sort.SliceStable(taskStatusSlice, func(i, j int) bool {
+		return taskStatusSlice[i].RunningTime.Before(taskStatusSlice[j].RunningTime)
+	})
+	if lastN > len(taskStatusSlice) {
+		lastN = len(taskStatusSlice)
+	}
+	return taskStatusSlice[len(taskStatusSlice)-lastN:]
+}
+
+func (aa *AppAnalyzer) GetTasksDistributionInfo(nodeInfos map[string]*NodeInfo) *TasksDistributionInfo {
+	nodeInfoSlice := make([]*NodeInfo, len(nodeInfos))
+	i := 0
+	for _, nodeInfo := range nodeInfos {
+		nodeInfoSlice[i] = nodeInfo
+		i++
+	}
+	sort.SliceStable(nodeInfoSlice, func(i, j int) bool {
+		return len(nodeInfoSlice[i].Tasks) < len(nodeInfoSlice[j].Tasks)
+	})
+	leastNodeInfo := nodeInfoSlice[0]
+	mostNodeInfo := nodeInfoSlice[len(nodeInfoSlice)-1]
+	return &TasksDistributionInfo{
+		LeastNum:        len(leastNodeInfo.Tasks),
+		LeastNumNodeID:  leastNodeInfo.NodeID,
+		MostNum:         len(mostNodeInfo.Tasks),
+		MostNumNodeID:   mostNodeInfo.NodeID,
+		AvgNum:          float64(len(aa.appInfo.TasksStatus)) / float64(len(nodeInfoSlice)),
+		SortedNodeInfos: nodeInfoSlice,
+	}
+}
+
+func (aa *AppAnalyzer) GetTasksDistribution(condType TaskConditionType) [][]*TaskStatus {
+	beginTime := aa.appInfo.AppStatus.CreateTime
+	endTime := aa.appInfo.AppStatus.RunningTime
+	maxSeconds := int(math.Floor(endTime.Sub(beginTime).Seconds()) + 1)
+	distribution := make([][]*TaskStatus, maxSeconds+1)
+	for _, status := range aa.appInfo.TasksStatus {
+		if condTransitionTime := status.GetTransitionTime(condType); condTransitionTime != nil {
+			seconds := int(math.Floor(condTransitionTime.Sub(beginTime).Seconds()) + 1)
+			if seconds < 0 {
+				utils.Logger.Warn("skip invalid task", zap.Any("beginTime", beginTime),
+					zap.Any("conditionType", condType), zap.Any("taskStatus", status))
+				continue
+			}
+			distribution[seconds] = append(distribution[seconds], status)
+		} else {
+			utils.Logger.Warn("skip invalid task", zap.Any("conditionType", condType),
+				zap.Any("taskStatus", status))
+			continue
+		}
+	}
+	// drop zero tail
+	lastNonZeroIndex := -1
+	for i := maxSeconds; i >= 0; i-- {
+		if len(distribution[i]) != 0 {
+			lastNonZeroIndex = i
+			break
+		}
+	}
+	return distribution[:lastNonZeroIndex+1]
+}
+
+func (aa *AppAnalyzer) GetTimeDistribution(condType TaskConditionType) []int {
+	tasksDistribution := aa.GetTasksDistribution(condType)
+	timeDistribution := make([]int, len(tasksDistribution))
+	for index, tasksInCurSecond := range tasksDistribution {
+		timeDistribution[index] = len(tasksInCurSecond)
+	}
+	return timeDistribution
+}
+
+func (aa *AppAnalyzer) GetTasksProfiling() profiling.Profiling {
+	beginTime := aa.appInfo.AppStatus.CreateTime
+	endTime := aa.appInfo.AppStatus.RunningTime
+	prof := profiling.NewProfilingWithTime(beginTime)
+	for _, ts := range aa.appInfo.TasksStatus {
+		prof.StartExecutionWithTime(ts.CreateTime)
+		for _, cond := range ts.Conditions {
+			prof.AddCheckpointWithTime(string(cond.CondType), cond.TransitionTime)
+		}
+		//lastCondTime := ts.Conditions[len(ts.Conditions)-1].TransitionTime
+		prof.FinishExecutionWithTime(true, endTime)
+	}
+	return prof
+}

--- a/perf-tools/framework/app_info.go
+++ b/perf-tools/framework/app_info.go
@@ -1,0 +1,149 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package framework
+
+import (
+	"time"
+
+	"github.com/apache/incubator-yunikorn-core/pkg/common/resources"
+
+	apiv1 "k8s.io/api/core/v1"
+)
+
+type AppInfo struct {
+	Namespace       string
+	AppID           string
+	Queue           string
+	RequestInfos    []*RequestInfo
+	PodSpec         apiv1.PodSpec
+	PodTemplateSpec apiv1.PodTemplateSpec
+	AppStatus       AppStatus
+	TasksStatus     map[string]*TaskStatus
+}
+
+type RequestInfo struct {
+	Number           int32
+	PriorityClass    string
+	RequestResources map[string]string
+	LimitResources   map[string]string
+}
+
+type AppStatus struct {
+	CreateTime time.Time
+	// running time of the last task
+	RunningTime time.Time
+	DesiredNum  int
+	CreatedNum  int
+	ReadyNum    int
+}
+
+type TaskStatus struct {
+	TaskID           string
+	CreateTime       time.Time
+	RunningTime      time.Time
+	NodeID           string
+	RequestResources *resources.Resource
+	Conditions       []*TaskCondition
+}
+
+type TaskCondition struct {
+	CondType       TaskConditionType
+	TransitionTime time.Time
+}
+
+type TasksDistributionInfo struct {
+	LeastNum        int
+	LeastNumNodeID  string
+	MostNum         int
+	MostNumNodeID   string
+	AvgNum          float64
+	SortedNodeInfos []*NodeInfo
+}
+
+type TaskConditionType string
+
+const (
+	PodCreated      TaskConditionType = "PodCreated"
+	PodScheduled    TaskConditionType = "PodScheduled"
+	PodStarted      TaskConditionType = "PodStarted"
+	PodInitialized  TaskConditionType = "Initialized"
+	PodReady        TaskConditionType = "Ready"
+	ContainersReady TaskConditionType = "ContainersReady"
+)
+
+func NewRequestInfo(number int32, priorityClass string, requestResources, limitResources map[string]string) *RequestInfo {
+	return &RequestInfo{
+		Number:           number,
+		PriorityClass:    priorityClass,
+		RequestResources: requestResources,
+		LimitResources:   limitResources,
+	}
+}
+
+func NewAppInfo(namespace, appID, queue string, requestInfos []*RequestInfo,
+	podTemplateSpec apiv1.PodTemplateSpec, podSpec apiv1.PodSpec) *AppInfo {
+	return &AppInfo{
+		Namespace:       namespace,
+		AppID:           appID,
+		Queue:           queue,
+		RequestInfos:    requestInfos,
+		PodTemplateSpec: podTemplateSpec,
+		PodSpec:         podSpec,
+	}
+}
+
+func NewTaskStatus(taskID, nodeID string, createTime, runningTime time.Time,
+	requestResources *resources.Resource, conditions []*TaskCondition) *TaskStatus {
+	return &TaskStatus{
+		TaskID:           taskID,
+		CreateTime:       createTime,
+		RunningTime:      runningTime,
+		NodeID:           nodeID,
+		RequestResources: requestResources,
+		Conditions:       conditions,
+	}
+}
+
+func (appInfo *AppInfo) SetAppStatus(desiredNum, createdNum, readyNum int) {
+	appInfo.AppStatus.DesiredNum = desiredNum
+	appInfo.AppStatus.CreatedNum = createdNum
+	appInfo.AppStatus.ReadyNum = readyNum
+}
+
+func (appInfo *AppInfo) GetDesiredNumTasks() int32 {
+	var desiredNum int32
+	for _, requestInfo := range appInfo.RequestInfos {
+		desiredNum += requestInfo.Number
+	}
+	return desiredNum
+}
+
+func (taskStatus *TaskStatus) GetTransitionTime(condType TaskConditionType) *time.Time {
+	for _, cond := range taskStatus.Conditions {
+		if cond.CondType == condType {
+			return &cond.TransitionTime
+		}
+	}
+	return nil
+}
+
+func GetOrderedTaskConditionTypes() []TaskConditionType {
+	return []TaskConditionType{PodCreated, PodScheduled,
+		PodStarted, PodInitialized, PodReady, ContainersReady}
+}

--- a/perf-tools/framework/app_manager.go
+++ b/perf-tools/framework/app_manager.go
@@ -1,0 +1,334 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/apache/incubator-yunikorn-release/perf-tools/constants"
+	"github.com/apache/incubator-yunikorn-release/perf-tools/utils"
+
+	"go.uber.org/zap"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type AppManager interface {
+	Create(schedulerName string, appInfo *AppInfo) error
+	Delete(appInfo *AppInfo) error
+	RefreshAppStatus(appInfo *AppInfo) error
+	RefreshTasksStatusAfterRunning(appInfo *AppInfo) error
+	WaitForAppsToBeCleanedUp(appInfos *AppInfo, timeout time.Duration) error
+	WaitForAppsToBeSatisfied(appInfos *AppInfo, timeout time.Duration) error
+	// create an app and wait for it to be running, refresh tasks status at last
+	CreateWaitAndRefreshTasksStatus(schedulerName string, appInfo *AppInfo, timeout time.Duration) error
+	// delete an app and wait for it to be cleaned up
+	DeleteWait(appInfo *AppInfo, timeout time.Duration) error
+}
+
+type DeploymentsAppManager struct {
+	kubeClient *utils.KubeClient
+	nameRegexp *regexp.Regexp
+}
+
+func NewDeploymentsAppManager(kubeClient *utils.KubeClient) AppManager {
+	regexp, _ := regexp.Compile(`[_\W]`)
+	return &DeploymentsAppManager{
+		kubeClient: kubeClient,
+		nameRegexp: regexp,
+	}
+}
+
+func (dam *DeploymentsAppManager) Create(schedulerName string, appInfo *AppInfo) error {
+	if len(appInfo.RequestInfos) == 0 {
+		return fmt.Errorf("request info not defined for app %s", appInfo.AppID)
+	}
+	for reqIndex, requestInfo := range appInfo.RequestInfos {
+		// init container
+		var container apiv1.Container
+		if len(appInfo.PodSpec.Containers) > 0 {
+			container = appInfo.PodSpec.Containers[0]
+		} else {
+			container = apiv1.Container{}
+			container.Name = constants.DefaultContainerName
+			container.Image = constants.DefaultContainerImage
+		}
+		if requestInfo.RequestResources != nil {
+			if container.Resources.Requests == nil {
+				container.Resources.Requests = apiv1.ResourceList{}
+			}
+			for resourceName, resourceValue := range requestInfo.RequestResources {
+				container.Resources.Requests[apiv1.ResourceName(resourceName)] = resource.MustParse(resourceValue)
+			}
+		}
+		if requestInfo.LimitResources != nil {
+			if container.Resources.Limits == nil {
+				container.Resources.Limits = apiv1.ResourceList{}
+			}
+			for resourceName, resourceValue := range requestInfo.LimitResources {
+				container.Resources.Limits[apiv1.ResourceName(resourceName)] = resource.MustParse(resourceValue)
+			}
+		}
+		// init and create deployment
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: appInfo.Namespace,
+				Name:      dam.getDeploymentName(appInfo, reqIndex),
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &requestInfo.Number,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constants.LabelAppID: appInfo.AppID,
+					},
+				},
+				Template: apiv1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							constants.LabelAppID: appInfo.AppID,
+							constants.LabelQueue: appInfo.Queue,
+						},
+						Annotations: appInfo.PodTemplateSpec.ObjectMeta.Annotations,
+					},
+					Spec: apiv1.PodSpec{
+						SchedulerName: schedulerName,
+						HostNetwork:   appInfo.PodSpec.HostNetwork,
+						Containers: []apiv1.Container{
+							container,
+						},
+						Tolerations:       appInfo.PodSpec.Tolerations,
+						NodeSelector:      appInfo.PodSpec.NodeSelector,
+						PriorityClassName: requestInfo.PriorityClass,
+					},
+				},
+			},
+		}
+		err := dam.kubeClient.CreateDeployment(appInfo.Namespace, deployment)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (dam *DeploymentsAppManager) getDeploymentName(appInfo *AppInfo, reqIndex int) string {
+	normalizedName := dam.nameRegexp.ReplaceAllString(appInfo.AppID, "-")
+	return fmt.Sprintf("%s-%d", normalizedName, reqIndex)
+}
+
+func (dam *DeploymentsAppManager) Delete(appInfo *AppInfo) error {
+	for i := 0; i < len(appInfo.RequestInfos); i++ {
+		err := dam.kubeClient.DeleteDeployment(appInfo.Namespace, dam.getDeploymentName(appInfo, i))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (dam *DeploymentsAppManager) RefreshAppStatus(appInfo *AppInfo) error {
+	var summaryMetrics [3]int
+	firstCreateTime := time.Time{}
+	for i := 0; i < len(appInfo.RequestInfos); i++ {
+		createTime, metrics, err := dam.kubeClient.GetDeploymentInfo(
+			appInfo.Namespace, dam.getDeploymentName(appInfo, i))
+		if err != nil {
+			utils.Logger.Info("failed to refresh app status", zap.Error(err))
+			continue
+		}
+		if firstCreateTime.IsZero() || firstCreateTime.After(createTime) {
+			firstCreateTime = createTime
+		}
+		summaryMetrics[0] += metrics[0]
+		summaryMetrics[1] += metrics[1]
+		summaryMetrics[2] += metrics[2]
+	}
+	appInfo.SetAppStatus(summaryMetrics[0], summaryMetrics[1], summaryMetrics[2])
+	return nil
+}
+
+func (dam *DeploymentsAppManager) RefreshTasksStatusAfterRunning(appInfo *AppInfo) error {
+	podList, err := dam.kubeClient.GetPods(appInfo.Namespace,
+		utils.GetListOptions(map[string]string{constants.LabelAppID: appInfo.AppID}))
+	if err != nil {
+		return err
+	}
+	tasksStatus := make(map[string]*TaskStatus)
+	maxRunningTime := time.Time{}
+	firstCreateTime := time.Time{}
+	for _, pod := range podList.Items {
+		createTime := pod.CreationTimestamp.Time
+		startTime := pod.Status.StartTime.Time
+		requestResources := ParseResourceFromResourceList(&pod.Spec.Containers[0].Resources.Requests)
+		// init conditions map
+		condMap := make(map[TaskConditionType]*TaskCondition)
+		condMap[PodCreated] = &TaskCondition{
+			CondType:       PodCreated,
+			TransitionTime: pod.CreationTimestamp.Time,
+		}
+		condMap[PodStarted] = &TaskCondition{
+			CondType:       PodStarted,
+			TransitionTime: startTime,
+		}
+		for _, cond := range pod.Status.Conditions {
+			condMap[TaskConditionType(cond.Type)] = &TaskCondition{
+				CondType:       TaskConditionType(cond.Type),
+				TransitionTime: cond.LastTransitionTime.Time,
+			}
+		}
+
+		// set running time from the last condition (ContainersReady)
+		var runningTime time.Time
+		if readyCond, ok := condMap[ContainersReady]; ok {
+			runningTime = readyCond.TransitionTime
+		} else {
+			utils.Logger.Fatal("unexpected conditions", zap.Any("Conditions", condMap))
+		}
+		// transfer to ordered conditions
+		orderedCondTypes := GetOrderedTaskConditionTypes()
+		conditions := make([]*TaskCondition, len(orderedCondTypes))
+		for idx, condType := range orderedCondTypes {
+			if cond, ok := condMap[condType]; ok {
+				conditions[idx] = cond
+			} else {
+				utils.Logger.Fatal("unknown condition", zap.Any("condType", condType),
+					zap.Any("podName", pod.Name))
+			}
+		}
+		taskStatus := NewTaskStatus(pod.Name, pod.Spec.NodeName,
+			createTime, runningTime, requestResources, conditions)
+		tasksStatus[taskStatus.TaskID] = taskStatus
+		// update maxRunningTime
+		if runningTime.After(maxRunningTime) {
+			maxRunningTime = runningTime
+		}
+		if firstCreateTime.IsZero() || createTime.Before(firstCreateTime) {
+			firstCreateTime = createTime
+		}
+	}
+	appInfo.TasksStatus = tasksStatus
+	appInfo.AppStatus.RunningTime = maxRunningTime
+	appInfo.AppStatus.CreateTime = firstCreateTime
+	return nil
+}
+
+func (dam *DeploymentsAppManager) WaitForAppsToBeCleanedUp(appInfo *AppInfo, timeout time.Duration) error {
+	startTime := time.Now()
+	i := 1
+	return waitForCondition(func() bool {
+		err := dam.RefreshAppStatus(appInfo)
+		if err != nil {
+			return true
+		}
+		if appInfo.AppStatus.DesiredNum != 0 || appInfo.AppStatus.CreatedNum != 0 || appInfo.AppStatus.ReadyNum != 0 {
+			if time.Since(startTime) > 60*time.Duration(i)*time.Second {
+				utils.Logger.Info("still waiting for app to be cleaned up",
+					zap.String("appID", appInfo.AppID),
+					zap.Duration("timeout", timeout),
+					zap.Duration("elapseTime", time.Since(startTime)),
+					zap.Int("desiredNum", appInfo.AppStatus.DesiredNum),
+					zap.Int("createdNum", appInfo.AppStatus.CreatedNum),
+					zap.Int("readyNum", appInfo.AppStatus.ReadyNum))
+				i++
+			}
+			return false
+		}
+		utils.Logger.Info("app is cleaned up", zap.String("appID", appInfo.AppID),
+			zap.Any("appStatus", appInfo.AppStatus))
+		return true
+	}, 1*time.Second, timeout)
+}
+
+func (dam *DeploymentsAppManager) WaitForAppsToBeSatisfied(appInfo *AppInfo, timeout time.Duration) error {
+	startTime := time.Now()
+	i := 1
+	return waitForCondition(func() bool {
+		err := dam.RefreshAppStatus(appInfo)
+		if err != nil {
+			return true
+		}
+		if appInfo.AppStatus.DesiredNum == 0 || appInfo.AppStatus.DesiredNum != appInfo.AppStatus.ReadyNum {
+			if time.Since(startTime) > 5*time.Duration(i)*time.Second {
+				utils.Logger.Info("still waiting for app to be running",
+					zap.String("appID", appInfo.AppID),
+					zap.Duration("timeout", timeout),
+					zap.Duration("elapseTime", time.Since(startTime)),
+					zap.Int("desiredNum", appInfo.AppStatus.DesiredNum),
+					zap.Int("readyNum", appInfo.AppStatus.ReadyNum))
+				i++
+			}
+			return false
+		}
+		return true
+	}, 1*time.Second, timeout)
+}
+
+func (dam *DeploymentsAppManager) CreateWaitAndRefreshTasksStatus(schedulerName string, appInfo *AppInfo,
+	timeout time.Duration) error {
+	err := dam.Create(schedulerName, appInfo)
+	if err != nil {
+		return fmt.Errorf("failed to create app: %s", err.Error())
+	}
+	// wait for this app to be running (all pods are scheduled to be running)
+	err = dam.WaitForAppsToBeSatisfied(appInfo, timeout)
+	if err != nil {
+		return fmt.Errorf("failed to wait for this app to be running: %s", err.Error())
+	}
+	// refresh task status
+	err = dam.RefreshTasksStatusAfterRunning(appInfo)
+	if err != nil {
+		return fmt.Errorf("failed to refresh task status: %s", err.Error())
+	}
+	return nil
+}
+
+func (dam *DeploymentsAppManager) DeleteWait(appInfo *AppInfo,
+	timeout time.Duration) error {
+	err := dam.Delete(appInfo)
+	if err != nil {
+		return fmt.Errorf("failed to delete app: %s", err.Error())
+	}
+	// wait for this app to be cleaned up
+	err = dam.WaitForAppsToBeCleanedUp(appInfo, timeout)
+	if err != nil {
+		return fmt.Errorf("failed to wait for this app to be cleaned up: %s", err.Error())
+	}
+	return nil
+}
+
+// copied from yunikorn-k8shim to avoid importing too many dependencies
+func waitForCondition(eval func() bool, interval time.Duration, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if eval() {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for condition")
+		}
+
+		time.Sleep(interval)
+	}
+}

--- a/perf-tools/framework/config.go
+++ b/perf-tools/framework/config.go
@@ -1,0 +1,59 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	apiv1 "k8s.io/api/core/v1"
+
+	"gopkg.in/yaml.v2"
+)
+
+type Config struct {
+	Common    *CommonConfig
+	Scenarios map[string]interface{}
+}
+
+type CommonConfig struct {
+	KubeConfigFile  string
+	SchedulerName   string
+	MaxWaitSeconds  int
+	Queue           string
+	Namespace       string
+	OutputRootPath  string
+	OutputPath      string
+	NodeSelector    string
+	PodSpec         apiv1.PodSpec
+	PodTemplateSpec apiv1.PodTemplateSpec
+}
+
+func InitConfig(configFile string) (*Config, error) {
+	yamlContent, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read config file: %s ", err.Error())
+	}
+	conf := Config{}
+	err = yaml.Unmarshal(yamlContent, &conf)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse config file: %s ", err.Error())
+	}
+	return &conf, nil
+}

--- a/perf-tools/framework/node_analyzer.go
+++ b/perf-tools/framework/node_analyzer.go
@@ -1,0 +1,184 @@
+package framework
+
+import (
+	"fmt"
+
+	"github.com/apache/incubator-yunikorn-core/pkg/common/resources"
+	"github.com/apache/incubator-yunikorn-release/perf-tools/utils"
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type NodeAnalyzer struct {
+	kubeClient       *utils.KubeClient
+	allocatableNodes map[string]*NodeInfo
+	nodeSelector     string
+}
+
+func NewNodeAnalyzer(kubeClient *utils.KubeClient, nodeSelector string) *NodeAnalyzer {
+	return &NodeAnalyzer{
+		kubeClient:   kubeClient,
+		nodeSelector: nodeSelector,
+	}
+}
+
+// InitNodeInfosBeforeTesting records the snapshot of schedulable and ready nodes before testing
+func (na *NodeAnalyzer) InitNodeInfosBeforeTesting() error {
+	// get resource map for schedulable nodes
+	nodes, err := na.kubeClient.GetNodes(&metav1.ListOptions{LabelSelector: na.nodeSelector})
+	if nodes == nil || err != nil {
+		return err
+	}
+	if len(nodes.Items) == 0 {
+		return fmt.Errorf("no selected nodes in k8s cluster, nodeSelector=%s", na.nodeSelector)
+	}
+	na.allocatableNodes = make(map[string]*NodeInfo)
+	for _, nodeItem := range nodes.Items {
+		if nodeItem.Spec.Unschedulable {
+			utils.Logger.Debug("skip unschedulable node", zap.String("nodeID", nodeItem.Name))
+			continue
+		}
+		if !IsNodeReady(&nodeItem) {
+			utils.Logger.Debug("skip not-ready node", zap.String("nodeID", nodeItem.Name))
+			continue
+		}
+		// allocatable resource is the upper limit of allocated resource for pods
+		capacityRes := ParseResourceFromResourceList(&nodeItem.Status.Allocatable)
+		nodeInfo := NewNodeInfo(nodeItem.Name, capacityRes, resources.NewResource())
+		na.allocatableNodes[nodeItem.Name] = nodeInfo
+	}
+	return nil
+}
+
+// CalculateAllocatedResource calculate allocated resource for nodes,
+// which may be rather time-consuming when there are numerous pods in the cluster,
+// so this should be called only if necessary!
+func (na *NodeAnalyzer) CalculateAllocatedResource() {
+	utils.Logger.Info("start loading all pods for calculating allocated resource")
+	podList, _ := na.kubeClient.GetPods("", utils.GetEverythingListOptions())
+	utils.Logger.Info(fmt.Sprintf("loaded %d pods", len(podList.Items)))
+	for _, pod := range podList.Items {
+		if pod.Spec.NodeName == "" {
+			continue
+		}
+		if node, ok := na.allocatableNodes[pod.Spec.NodeName]; ok {
+			node.AllocatedResource.NodeResourceBefore.AddTo(GetPodRequestResource(&pod))
+		}
+	}
+	utils.Logger.Info("calculated allocated resource successfully")
+}
+
+func (na *NodeAnalyzer) ClearApps() {
+	for _, nodeInfo := range na.allocatableNodes {
+		nodeInfo.ClearTasks()
+	}
+}
+
+// AnalyzeApp updates the state of nodes according to app status
+func (na *NodeAnalyzer) AnalyzeApp(appInfo *AppInfo) {
+	for _, taskStatus := range appInfo.TasksStatus {
+		if nodeInfo, ok := na.allocatableNodes[taskStatus.NodeID]; ok {
+			nodeInfo.AddTask(taskStatus)
+		}
+	}
+}
+
+func (na *NodeAnalyzer) GetAllocatableNodes() map[string]*NodeInfo {
+	return na.allocatableNodes
+}
+
+func (na *NodeAnalyzer) GetScheduledNodes() map[string]*NodeInfo {
+	relatedNodeInfos := make(map[string]*NodeInfo)
+	for nodeID, nodeInfo := range na.allocatableNodes {
+		if len(nodeInfo.Tasks) > 0 {
+			relatedNodeInfos[nodeID] = nodeInfo
+		}
+	}
+	return relatedNodeInfos
+}
+
+func (na *NodeAnalyzer) GetTotalAllocatableResource() *resources.Resource {
+	totalAllocatableResource := resources.NewResource()
+	for _, nodeInfo := range na.allocatableNodes {
+		nodeAllocatedRes := nodeInfo.AllocatedResource.GetResource()
+		nodeAllocatableRes := resources.Sub(nodeInfo.Capacity, nodeAllocatedRes)
+		totalAllocatableResource.AddTo(nodeAllocatableRes)
+	}
+	return totalAllocatableResource
+}
+
+func (na *NodeAnalyzer) GetNodeResourceDistribution(tasksDistribution [][]*TaskStatus,
+	resourceName string) [10][]int {
+	// init node resources, key(string): <NodeID>, value([]int64): <CapacityResourceValue>, <AllocatedResourceValue>
+	nodeResources := make(map[string][]int64)
+	for nodeID, nodeInfo := range na.allocatableNodes {
+		nodeResources[nodeID] = []int64{int64(nodeInfo.Capacity.Resources[resourceName]),
+			int64(nodeInfo.AllocatedResource.GetResource().Resources[resourceName])}
+	}
+	// statistic the number of nodes in 10 buckets with different resource utilization levels
+	// ([0%,10%), [10%,20%), ..., [90%,100%]) in every second
+	var buckets [10][]int
+	for _, tasksInCurSecond := range tasksDistribution {
+		for _, taskStatus := range tasksInCurSecond {
+			nodeResources[taskStatus.NodeID][1] += int64(taskStatus.RequestResources.Resources[resourceName])
+		}
+		// calculate current distribution
+		bucketsInThisSecond := calculateResourceDistribution(nodeResources)
+		for level, num := range bucketsInThisSecond {
+			buckets[level] = append(buckets[level], num)
+		}
+	}
+	return buckets
+}
+
+func calculateResourceDistribution(resources map[string][]int64) [10]int {
+	var buckets [10]int
+	for _, resourceValues := range resources {
+		if len(resourceValues) == 2 {
+			ratio := float32(resourceValues[1]*10) / float32(resourceValues[0])
+			bucketIndex := int(ratio)
+			if bucketIndex == 10 {
+				bucketIndex = 9
+			}
+			buckets[bucketIndex] += 1
+		} else {
+			panic(fmt.Errorf("Error resources: %+v ", resourceValues))
+		}
+	}
+	return buckets
+}
+
+func ParseResourceFromResourceList(resourceList *v1.ResourceList) *resources.Resource {
+	resourceMap := make(map[string]resources.Quantity)
+	for name, value := range *resourceList {
+		switch name {
+		case v1.ResourceMemory:
+			resourceMap[resources.MEMORY] = resources.Quantity(value.ScaledValue(resource.Mega))
+		case v1.ResourceCPU:
+			resourceMap[resources.VCORE] = resources.Quantity(value.MilliValue())
+		default:
+			resourceMap[name.String()] = resources.Quantity(value.Value())
+		}
+	}
+	return resources.NewResourceFromMap(resourceMap)
+}
+
+// IsNodeReady returns true if a node is ready, false otherwise.
+func IsNodeReady(node *v1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == v1.NodeReady {
+			return c.Status == v1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func GetPodRequestResource(pod *v1.Pod) *resources.Resource {
+	resource := resources.NewResource()
+	for _, container := range pod.Spec.Containers {
+		resource.AddTo(ParseResourceFromResourceList(&container.Resources.Requests))
+	}
+	return resource
+}

--- a/perf-tools/framework/node_info.go
+++ b/perf-tools/framework/node_info.go
@@ -1,0 +1,84 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+
+	"github.com/apache/incubator-yunikorn-core/pkg/common/resources"
+)
+
+type NodeInfo struct {
+	NodeID            string
+	Tasks             map[string]*TaskStatus
+	Capacity          *resources.Resource
+	AllocatedResource ResourceInfo
+}
+
+type ResourceInfo struct {
+	NodeResourceBefore *resources.Resource
+	TasksTotalResource *resources.Resource
+	NumTasks           int
+}
+
+func NewNodeInfo(nodeID string, capacityRes *resources.Resource, allocatedRes *resources.Resource) *NodeInfo {
+	return &NodeInfo{
+		NodeID:   nodeID,
+		Tasks:    make(map[string]*TaskStatus),
+		Capacity: capacityRes,
+		AllocatedResource: ResourceInfo{
+			NodeResourceBefore: allocatedRes,
+			TasksTotalResource: resources.NewResource(),
+		},
+	}
+}
+
+func (ni *NodeInfo) AddTask(task *TaskStatus) {
+	ni.Tasks[task.TaskID] = task
+	ni.AllocatedResource.AddTaskResource(task.RequestResources)
+}
+
+func (ni *NodeInfo) ClearTasks() {
+	ni.Tasks = make(map[string]*TaskStatus)
+	ni.AllocatedResource.ClearTaskResources()
+}
+
+func (ni *NodeInfo) GetSummary() string {
+	return fmt.Sprintf("nodeID=%s, numTasks=%d, capacity=%+v, allocatedRes=%+v",
+		ni.NodeID, len(ni.Tasks), ni.Capacity, ni.AllocatedResource)
+}
+
+func (ri *ResourceInfo) AddTaskResource(taskReqResources *resources.Resource) {
+	if ri.TasksTotalResource == nil {
+		ri.TasksTotalResource = resources.NewResource()
+	}
+	ri.TasksTotalResource.AddTo(taskReqResources)
+	ri.NumTasks++
+}
+
+func (ri *ResourceInfo) ClearTaskResources() {
+	ri.NumTasks = 0
+	ri.TasksTotalResource = resources.NewResource()
+}
+
+func (ri *ResourceInfo) GetResource() *resources.Resource {
+	resource := ri.NodeResourceBefore.Clone()
+	resource.AddTo(ri.TasksTotalResource)
+	return resource
+}

--- a/perf-tools/framework/scenarios.go
+++ b/perf-tools/framework/scenarios.go
@@ -1,0 +1,49 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package framework
+
+import (
+	"github.com/apache/incubator-yunikorn-release/perf-tools/utils"
+	"go.uber.org/zap"
+)
+
+type TestScenarios struct {
+	registeredTestScenarios map[string]TestScenario
+}
+
+var testScenarios TestScenarios
+
+func init() {
+	testScenarios.registeredTestScenarios = make(map[string]TestScenario)
+}
+
+func Register(ts TestScenario) {
+	testScenarios.registeredTestScenarios[ts.GetName()] = ts
+	utils.Logger.Info("register scenario", zap.String("scenarioName", ts.GetName()))
+}
+
+func GetRegisteredTestScenarios() map[string]TestScenario {
+	return testScenarios.registeredTestScenarios
+}
+
+type TestScenario interface {
+	GetName() string
+	Init(kubeClient *utils.KubeClient, config *Config) error
+	Run(results *utils.Results)
+}

--- a/perf-tools/main.go
+++ b/perf-tools/main.go
@@ -1,0 +1,141 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/apache/incubator-yunikorn-release/perf-tools/utils"
+
+	"github.com/apache/incubator-yunikorn-release/perf-tools/framework"
+	_ "github.com/apache/incubator-yunikorn-release/perf-tools/scenarios"
+	"go.uber.org/zap"
+)
+
+const (
+	DateTimeLayout      = "20060102150405"
+	ConfigFileName      = "conf.yaml"
+	OutputDirNamePrefix = "YK-PERF"
+	DefaultLoggingLevel = 0
+)
+
+type CommandLineConfig struct {
+	ConfigFilePath string
+	ScenarioNames  string
+	LogLevel       int
+}
+
+var commandLineConfig *CommandLineConfig
+
+func init() {
+	// test options
+	configFile := flag.String("config", "",
+		"absolute path to the config file for performance tests")
+	scenarioNames := flag.String("scenarios", "",
+		"The comma separated names of scenarios which are expected to run")
+	logLevel := flag.Int("logLevel", DefaultLoggingLevel,
+		"logging level, available range [-1, 5], from DEBUG to FATAL.")
+	flag.Parse()
+	commandLineConfig = &CommandLineConfig{
+		ConfigFilePath: *configFile,
+		ScenarioNames:  *scenarioNames,
+		LogLevel:       *logLevel,
+	}
+}
+
+func main() {
+	utils.SetLogLevel(commandLineConfig.LogLevel)
+	configFilePath := commandLineConfig.ConfigFilePath
+	if configFilePath == "" {
+		err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			} else if info.Name() == ConfigFileName {
+				configFilePath = path
+				return io.EOF
+			}
+			return nil
+		})
+		if err != io.EOF {
+			utils.Logger.Fatal("failed to find config file", zap.Error(err))
+		}
+		if configFilePath == "" {
+			utils.Logger.Fatal("can't find required config file for integration testing")
+		}
+	}
+	conf, err := framework.InitConfig(configFilePath)
+	if err != nil {
+		utils.Logger.Fatal("failed to initialize config", zap.Error(err))
+	}
+	// init kubeClient
+	kubeClient, err := utils.NewKubeClient(conf.Common.KubeConfigFile)
+	if err != nil {
+		utils.Logger.Fatal("failed to initialize kube-client", zap.Error(err))
+	}
+	// prepare expected test scenarios due to optional flag "scenarios",
+	// set to all registered test scenarios if not configured.
+	expectedTestScenarios := make([]framework.TestScenario, 0)
+	if commandLineConfig.ScenarioNames != "" {
+		for _, scenarioName := range strings.Split(commandLineConfig.ScenarioNames, ",") {
+			if ts := framework.GetRegisteredTestScenarios()[scenarioName]; ts != nil {
+				expectedTestScenarios = append(expectedTestScenarios, ts)
+			} else {
+				utils.Logger.Fatal("can't find specified scenario",
+					zap.String("specifiedScenarioName", scenarioName),
+					zap.Any("registeredTestScenarios", framework.GetRegisteredTestScenarios()))
+			}
+		}
+	} else {
+		for _, ts := range framework.GetRegisteredTestScenarios() {
+			expectedTestScenarios = append(expectedTestScenarios, ts)
+		}
+	}
+	// prepare output directory
+	outputTime := time.Now().Format(DateTimeLayout)
+	conf.Common.OutputPath = fmt.Sprintf("%s/%s-%s-%s",
+		conf.Common.OutputRootPath, OutputDirNamePrefix, commandLineConfig.ScenarioNames, outputTime)
+	err = os.Mkdir(conf.Common.OutputPath, os.ModePerm)
+	if err != nil {
+		utils.Logger.Fatal("failed to create output directory",
+			zap.String("outputPath", conf.Common.OutputPath), zap.Error(err))
+	}
+	// init expected test scenarios first
+	for _, testScenario := range expectedTestScenarios {
+		err := testScenario.Init(kubeClient, conf)
+		if err != nil {
+			utils.Logger.Fatal("failed to initialize scenario",
+				zap.String("scenarioName", testScenario.GetName()),
+				zap.Error(err))
+		}
+	}
+	// run expected test scenarios
+	results := utils.NewResults()
+	for _, testScenario := range expectedTestScenarios {
+		testScenario.Run(results)
+	}
+	utils.Logger.Info("all tests have been done, generate report")
+	results.RefreshStatus()
+	fmt.Println(results.String())
+}

--- a/perf-tools/scenarios/common.go
+++ b/perf-tools/scenarios/common.go
@@ -1,0 +1,53 @@
+package scenarios
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/apache/incubator-yunikorn-release/perf-tools/framework"
+	"github.com/apache/incubator-yunikorn-release/perf-tools/utils"
+	"github.com/mitchellh/mapstructure"
+	"go.uber.org/zap"
+)
+
+func LoadScenarioConf(conf *framework.Config, scenarioName string, scenarioConf interface{}) error {
+	rawScenarioConf := conf.Scenarios[scenarioName]
+	if rawScenarioConf == nil {
+		return fmt.Errorf("failed to load %s scenario config", scenarioName)
+	}
+	err := mapstructure.Decode(rawScenarioConf, scenarioConf)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s scenario config: %s", scenarioName, err.Error())
+	}
+	utils.Logger.Info("initialized scenario config", zap.String("scenarioName", scenarioName),
+		zap.Any("conf", scenarioConf))
+	return nil
+}
+
+func CleanupApp(appManager framework.AppManager, appInfo *framework.AppInfo, maxWaitTime time.Duration) {
+	if appManager != nil && appInfo != nil {
+		utils.Logger.Info("make sure app is cleaned up", zap.Any("appID", appInfo.AppID))
+		if err := appManager.DeleteWait(appInfo, maxWaitTime); err != nil {
+			utils.Logger.Info("failed to cleanup app", zap.Error(err))
+		}
+	}
+}
+
+type RequestConfig struct {
+	NumPods          int32
+	Repeat           int
+	PriorityClass    string
+	RequestResources map[string]string
+	LimitResources   map[string]string
+}
+
+func ConvertToRequestInfos(requestConfigs []*RequestConfig) []*framework.RequestInfo {
+	requestInfos := make([]*framework.RequestInfo, 0)
+	for _, requestConfig := range requestConfigs {
+		for i := 0; i < requestConfig.Repeat; i++ {
+			requestInfos = append(requestInfos, framework.NewRequestInfo(requestConfig.NumPods,
+				requestConfig.PriorityClass, requestConfig.RequestResources, requestConfig.LimitResources))
+		}
+	}
+	return requestInfos
+}

--- a/perf-tools/scenarios/e2e_perf.go
+++ b/perf-tools/scenarios/e2e_perf.go
@@ -1,0 +1,253 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package scenarios
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/TaoYang526/goutils/pkg/profiling"
+	"github.com/apache/incubator-yunikorn-release/perf-tools/framework"
+	"github.com/apache/incubator-yunikorn-release/perf-tools/utils"
+	"go.uber.org/zap"
+)
+
+const E2EPerfScenarioName = "e2e_perf"
+
+type E2EPerfScenario struct {
+	kubeClient   *utils.KubeClient
+	commonConf   *framework.CommonConfig
+	scenarioConf *E2EPerfScenarioConfig
+}
+
+type E2EPerfScenarioConfig struct {
+	CleanUpDelayMs     int
+	ShowNumOfLastTasks int
+	Cases              []*E2EPerfCaseConfig
+}
+
+type E2EPerfCaseConfig struct {
+	Description    string
+	SchedulerName  string
+	RequestConfigs []*RequestConfig
+}
+
+func init() {
+	framework.Register(&E2EPerfScenario{})
+}
+
+func (ts *E2EPerfScenario) GetName() string {
+	return E2EPerfScenarioName
+}
+
+func (ts *E2EPerfScenario) Init(kubeClient *utils.KubeClient, conf *framework.Config) error {
+	ts.kubeClient = kubeClient
+	ts.commonConf = conf.Common
+	ts.scenarioConf = &E2EPerfScenarioConfig{}
+	return LoadScenarioConf(conf, ts.GetName(), ts.scenarioConf)
+}
+
+func (eps *E2EPerfScenario) Run(results *utils.Results) {
+	scenarioResults := results.CreateScenarioResults(eps.GetName())
+	maxWaitTime := time.Duration(eps.commonConf.MaxWaitSeconds) * time.Second
+	var appManager framework.AppManager
+	var appInfo *framework.AppInfo
+	// make sure app is cleaned up when error occurred
+	defer func() {
+		CleanupApp(appManager, appInfo, maxWaitTime)
+	}()
+
+	for caseIndex, testCase := range eps.scenarioConf.Cases {
+		verGroupName := fmt.Sprintf("Case-%d", caseIndex)
+		verGroupDescription := fmt.Sprintf("%+v", testCase.Description)
+		caseVerification := scenarioResults.AddVerificationGroup(verGroupName, verGroupDescription)
+		utils.Logger.Info("[Prepare] add verification group",
+			zap.Int("caseIndex", caseIndex),
+			zap.String("name", verGroupName),
+			zap.String("description", verGroupDescription))
+		// init app info, app manager, app analyzer and node analyzer
+		requestInfos := ConvertToRequestInfos(testCase.RequestConfigs)
+		appInfo = framework.NewAppInfo(eps.commonConf.Namespace, E2EPerfScenarioName, eps.commonConf.Queue,
+			requestInfos, eps.commonConf.PodTemplateSpec, eps.commonConf.PodSpec)
+		appManager = framework.NewDeploymentsAppManager(eps.kubeClient)
+		appAnalyzer := framework.NewAppAnalyzer(appInfo)
+		nodeAnalyzer := framework.NewNodeAnalyzer(eps.kubeClient, eps.commonConf.NodeSelector)
+
+		schedulerName := testCase.SchedulerName
+
+		// prepare nodes
+		err := nodeAnalyzer.InitNodeInfosBeforeTesting()
+		if err != nil {
+			utils.Logger.Error("failed to init nodes", zap.Error(err))
+			caseVerification.AddSubVerification("init nodes", err.Error(), utils.FAILED)
+			return
+		}
+		utils.Logger.Info("[Prepare] init nodes", zap.Int("numNodes", len(nodeAnalyzer.GetAllocatableNodes())))
+
+		// create app and wait for it to be running
+		utils.Logger.Info("[Testing] create an app and wait for it to be running, refresh tasks status at last",
+			zap.String("appID", appInfo.AppID))
+		beginTime := time.Now().Truncate(time.Second)
+		err = appManager.CreateWaitAndRefreshTasksStatus(schedulerName, appInfo, maxWaitTime)
+		if err != nil {
+			utils.Logger.Error("failed to create/wait/refresh app", zap.Error(err))
+			caseVerification.AddSubVerification("test app", err.Error(), utils.FAILED)
+			return
+		}
+		utils.Logger.Info("all requirements of this app are satisfied",
+			zap.String("appID", appInfo.AppID),
+			zap.Duration("elapseTime", time.Since(beginTime)))
+
+		// fulfill nodes info after testing
+		nodeAnalyzer.AnalyzeApp(appInfo)
+		scheduledNodes := nodeAnalyzer.GetScheduledNodes()
+		utils.Logger.Info("got related nodes", zap.Int("numScheduledNodes", len(scheduledNodes)))
+
+		// analyze-1: print slow tasks (optional)
+		if eps.scenarioConf.ShowNumOfLastTasks > 0 {
+			slowTasksStatus := appAnalyzer.GetLastTasks(eps.scenarioConf.ShowNumOfLastTasks)
+			utils.Logger.Info(fmt.Sprintf("[Analyze] Show last %d tasks: ", len(slowTasksStatus)))
+			for _, task := range slowTasksStatus {
+				utils.Logger.Info("task status",
+					zap.String("taskID", task.TaskID),
+					zap.String("nodeID", task.NodeID),
+					zap.Duration("to-running-duration", task.RunningTime.Sub(task.CreateTime)),
+					zap.Time("createTime", task.CreateTime),
+					zap.Time("runningTime", task.RunningTime))
+			}
+		}
+		// analyze-2: print tasks distribution on nodes
+		tasksDistributionInfo := appAnalyzer.GetTasksDistributionInfo(scheduledNodes)
+		utils.Logger.Info("[Analyze] tasks distribution info on nodes",
+			zap.Int("LeastNum", tasksDistributionInfo.LeastNum),
+			zap.String("LeastNumNodeID", tasksDistributionInfo.LeastNumNodeID),
+			zap.Int("MostNum", tasksDistributionInfo.MostNum),
+			zap.String("MostNumNodeID", tasksDistributionInfo.MostNumNodeID),
+			zap.Float64("AvgNumPerNode", tasksDistributionInfo.AvgNum),
+			zap.Int("NumTasks", len(appInfo.TasksStatus)),
+			zap.Int("NumScheduledNodes", len(scheduledNodes)))
+		utils.Logger.Info("node with least number of tasks", zap.Any("summary",
+			tasksDistributionInfo.SortedNodeInfos[0].GetSummary()))
+		utils.Logger.Info("node with most number of tasks", zap.Any("summary",
+			tasksDistributionInfo.SortedNodeInfos[len(tasksDistributionInfo.SortedNodeInfos)-1].GetSummary()))
+
+		// profiling
+		prof := appAnalyzer.GetTasksProfiling()
+		if prof.GetCount() > 0 {
+			utils.Logger.Info("[Analyze] time statistics for pod conditions")
+			statsTableFilePath := fmt.Sprintf("%s/%s-case%d-timecost-stat.txt",
+				eps.commonConf.OutputPath, eps.GetName(), caseIndex)
+			statsOutputName := "time statistics"
+			stats := prof.GetTimeStatistics()
+			statsTable := ParseTableFromStatistic(stats)
+			if err := statsTable.Output(statsTableFilePath); err != nil {
+				caseVerification.AddSubVerification(statsOutputName,
+					fmt.Sprintf("failed to output %s: %s", statsOutputName, err.Error()),
+					utils.FAILED)
+				return
+			}
+			caseVerification.AddSubVerification(statsOutputName, statsTableFilePath, utils.SUCCEEDED)
+			statsTable.Print()
+			utils.Logger.Info("[Analyze] QPS statistics for pod conditions")
+			qpsStatsTableFilePath := fmt.Sprintf("%s/%s-case%d-qps-stat.txt",
+				eps.commonConf.OutputPath, eps.GetName(), caseIndex)
+			qpsStatsOutputName := "QPS statistics"
+			qpsStat, err := prof.GetQPSStatistics()
+			if err != nil {
+				caseVerification.AddSubVerification(qpsStatsOutputName,
+					fmt.Sprintf("failed to output %s: %s", qpsStatsOutputName, err.Error()),
+					utils.FAILED)
+			}
+			qpsStatsTable := ParseTableFromQPSStatistics(qpsStat, framework.GetOrderedTaskConditionTypes())
+			if err := qpsStatsTable.Output(qpsStatsTableFilePath); err != nil {
+				caseVerification.AddSubVerification(qpsStatsOutputName,
+					fmt.Sprintf("failed to output %s: %s", qpsStatsOutputName, err.Error()),
+					utils.FAILED)
+				return
+			}
+			caseVerification.AddSubVerification(qpsStatsOutputName, qpsStatsTableFilePath, utils.SUCCEEDED)
+			qpsStatsTable.Print()
+		}
+
+		if eps.scenarioConf.CleanUpDelayMs > 0 {
+			utils.Logger.Info("wait for a while before cleaning up test apps",
+				zap.String("schedulerName", schedulerName),
+				zap.Any("cleanUpDelayMs", eps.scenarioConf.CleanUpDelayMs))
+			time.Sleep(time.Millisecond * time.Duration(eps.scenarioConf.CleanUpDelayMs))
+		}
+
+		// delete this app and wait for it to be cleaned up
+		utils.Logger.Info("[Cleanup] delete this app then wait for it to be cleaned up",
+			zap.String("appID", appInfo.AppID))
+		err = appManager.DeleteWait(appInfo, maxWaitTime)
+		if err != nil {
+			utils.Logger.Error("failed to delete/wait app", zap.Error(err))
+			caseVerification.AddSubVerification("cleanup app", err.Error(), utils.FAILED)
+			return
+		}
+	}
+}
+
+func ParseTableFromStatistic(statistics *profiling.TimeStatistics) *utils.Table {
+	var data [][]string
+	for _, stat := range statistics.StagesTime {
+		rowData := []string{stat.From, stat.To, strconv.Itoa(stat.Count),
+			stat.TotalTime.String(), stat.AvgTime.String(),
+			fmt.Sprintf("%.2f", stat.Percentage)}
+		data = append(data, rowData)
+	}
+	return &utils.Table{
+		Headers: []string{"From", "To", "Count", "TotalTime", "AvgTime", "Percentage"},
+		Data:    data,
+	}
+}
+
+func ParseTableFromQPSStatistics(statistics *profiling.QPSStatistics, orderedKeys []framework.TaskConditionType) *utils.Table {
+	var data [][]string
+	if len(orderedKeys) > 0 {
+		for _, key := range orderedKeys {
+			if stat := getStageQPS(statistics.StagesQPS, ")"+string(key)); stat != nil {
+				rowData := []string{stat.To, strconv.Itoa(stat.MaxQPS),
+					fmt.Sprintf("%.2f", stat.AvgQPS), fmt.Sprintf("%+v", stat.Samples)}
+				data = append(data, rowData)
+			}
+		}
+	} else {
+		for _, stat := range statistics.StagesQPS {
+			rowData := []string{stat.To, strconv.Itoa(stat.MaxQPS),
+				fmt.Sprintf("%.2f", stat.AvgQPS), fmt.Sprintf("%+v", stat.Samples)}
+			data = append(data, rowData)
+		}
+	}
+	return &utils.Table{
+		Headers: []string{"To", "MaxQPS", "AvgQPS", "Samples"},
+		Data:    data,
+	}
+}
+
+func getStageQPS(qpsMap map[string]*profiling.StageQPS, suffix string) *profiling.StageQPS {
+	for key, item := range qpsMap {
+		if strings.HasSuffix(key, suffix) {
+			return item
+		}
+	}
+	return nil
+}

--- a/perf-tools/scenarios/node_fairness.go
+++ b/perf-tools/scenarios/node_fairness.go
@@ -1,0 +1,235 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package scenarios
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/apache/incubator-yunikorn-core/pkg/common/resources"
+	"github.com/apache/incubator-yunikorn-release/perf-tools/constants"
+	"github.com/apache/incubator-yunikorn-release/perf-tools/utils"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/apache/incubator-yunikorn-release/perf-tools/framework"
+	"go.uber.org/zap"
+)
+
+const NodeFairnessScenarioName = "node_fairness"
+
+type NodeFairnessScenario struct {
+	kubeClient   *utils.KubeClient
+	commonConf   *framework.CommonConfig
+	scenarioConf *NodeFairnessScenarioConfig
+}
+
+type NodeFairnessScenarioConfig struct {
+	SchedulerNames []string
+	Cases          []NodeFairnessCaseConfig
+}
+
+type NodeFairnessCaseConfig struct {
+	NumPodsPerNode     int
+	AllocatePercentage int
+	ResourceName       string
+}
+
+func init() {
+	framework.Register(&NodeFairnessScenario{})
+}
+
+func (nfs *NodeFairnessScenario) GetName() string {
+	return NodeFairnessScenarioName
+}
+
+func (nfs *NodeFairnessScenario) Init(kubeClient *utils.KubeClient, conf *framework.Config) error {
+	nfs.kubeClient = kubeClient
+	nfs.commonConf = conf.Common
+	nfs.scenarioConf = &NodeFairnessScenarioConfig{}
+	return LoadScenarioConf(conf, nfs.GetName(), nfs.scenarioConf)
+}
+
+func (nfs *NodeFairnessScenario) Run(results *utils.Results) {
+	scenarioResults := results.CreateScenarioResults(nfs.GetName())
+	maxWaitTime := time.Duration(nfs.commonConf.MaxWaitSeconds) * time.Second
+	var appManager framework.AppManager
+	var appInfo *framework.AppInfo
+	// make sure app is cleaned up when error occurred
+	defer func() {
+		CleanupApp(appManager, appInfo, maxWaitTime)
+	}()
+
+	// init node analyzer and calculate allocated resource for nodes
+	nodeAnalyzer := framework.NewNodeAnalyzer(nfs.kubeClient, nfs.commonConf.NodeSelector)
+	err := nodeAnalyzer.InitNodeInfosBeforeTesting()
+	if err != nil {
+		utils.Logger.Error("failed to init nodes", zap.Error(err))
+		scenarioResults.AddVerification("init nodes", err.Error(), utils.FAILED)
+		return
+	}
+	utils.Logger.Info("[Prepare] init nodes", zap.Int("numNodes", len(nodeAnalyzer.GetAllocatableNodes())))
+	nodeAnalyzer.CalculateAllocatedResource()
+
+	for caseIndex, testCase := range nfs.scenarioConf.Cases {
+		verGroupName := fmt.Sprintf("Case-%d", caseIndex)
+		verGroupDescription := fmt.Sprintf("%+v", testCase)
+		caseVerification := scenarioResults.AddVerificationGroup(verGroupName, verGroupDescription)
+		utils.Logger.Info("add verification group", zap.String("name", verGroupName),
+			zap.String("description", verGroupDescription))
+
+		nodeAnalyzer.ClearApps()
+		totalAllocatableResource := nodeAnalyzer.GetTotalAllocatableResource()
+		var resourceUnit string
+		ykResourceName := testCase.ResourceName
+		if testCase.ResourceName == v1.ResourceMemory.String() {
+			resourceUnit = "Mi"
+		} else if testCase.ResourceName == v1.ResourceCPU.String() {
+			resourceUnit = "m"
+			ykResourceName = resources.VCORE
+		}
+		totalAllocatableResourceValue, ok := totalAllocatableResource.Resources[ykResourceName]
+		if !ok {
+			caseVerification.AddSubVerification("Unknown resource name",
+				fmt.Sprintf("resourceName=%s, totalAllocatableResource=%v",
+					ykResourceName, totalAllocatableResource), utils.FAILED)
+			return
+		}
+
+		// init expected number of pods
+		allocatableNodes := nodeAnalyzer.GetAllocatableNodes()
+		expectedNumPods := testCase.NumPodsPerNode * len(allocatableNodes)
+		expectedPodResource := int64(totalAllocatableResourceValue) * int64(testCase.AllocatePercentage) /
+			int64(expectedNumPods*100)
+		requestResources := make(map[string]string)
+		requestResources[testCase.ResourceName] = fmt.Sprintf("%d"+resourceUnit, expectedPodResource)
+		utils.Logger.Info("start testing",
+			zap.Int("numAllocatableNodes", len(allocatableNodes)),
+			zap.Int("expectedNumPods", expectedNumPods),
+			zap.Any("requestResources", requestResources))
+
+		// init app info & app manager
+		requestInfo := framework.NewRequestInfo(int32(expectedNumPods), "", requestResources, nil)
+		appInfo = framework.NewAppInfo(nfs.commonConf.Namespace, NodeFairnessScenarioName, nfs.commonConf.Queue,
+			[]*framework.RequestInfo{requestInfo}, nfs.commonConf.PodTemplateSpec, nfs.commonConf.PodSpec)
+		appManager = framework.NewDeploymentsAppManager(nfs.kubeClient)
+		appAnalyzer := framework.NewAppAnalyzer(appInfo)
+
+		// test for different schedulers
+		for _, schedulerName := range nfs.scenarioConf.SchedulerNames {
+			utils.Logger.Info("start testing for scheduler " + schedulerName)
+			schedulerVerification := caseVerification.AddSubVerificationGroup(
+				fmt.Sprintf("test for %s", schedulerName), verGroupDescription)
+
+			// prepare nodes
+			nodeAnalyzer.ClearApps()
+			utils.Logger.Info("[Prepare] init nodes", zap.Int("numNodes", len(nodeAnalyzer.GetAllocatableNodes())))
+
+			// create app and wait for it to be running
+			utils.Logger.Info("create an app and wait for it to be running, refresh tasks status at last",
+				zap.String("appID", appInfo.AppID))
+			beginTime := time.Now().Truncate(time.Second)
+			err = appManager.CreateWaitAndRefreshTasksStatus(schedulerName, appInfo, maxWaitTime)
+			if err != nil {
+				utils.Logger.Error("failed to create/wait/refresh app", zap.Error(err))
+				schedulerVerification.AddSubVerification("test app", err.Error(), utils.FAILED)
+				return
+			}
+			utils.Logger.Info("all requirements of this app are satisfied", zap.String("appID", appInfo.AppID),
+				zap.Duration("elapseTime", time.Since(beginTime)))
+
+			// analyze
+			nodeDistribution := nodeAnalyzer.GetNodeResourceDistribution(
+				appAnalyzer.GetTasksDistribution(framework.PodScheduled), ykResourceName)
+
+			table := parseTableFromNodeDistribution(nodeDistribution)
+			tableFilePath := fmt.Sprintf("%s/%s-case%d-node-distribution.txt",
+				nfs.commonConf.OutputPath, nfs.GetName(), caseIndex)
+			tableOutputName := "output node distribution timeline table"
+			utils.Logger.Info(tableOutputName)
+			table.Print()
+			if err := table.Output(tableFilePath); err != nil {
+				schedulerVerification.AddSubVerification(tableOutputName,
+					fmt.Sprintf("failed to output node distribution timeline table: %s", err.Error()),
+					utils.FAILED)
+				return
+			}
+			schedulerVerification.AddSubVerification(tableOutputName, tableFilePath, utils.SUCCEEDED)
+
+			// prepare line points
+			var linePoints []interface{}
+			for i, v := range nodeDistribution {
+				typeName := "bucket-" + strconv.Itoa(i)
+				linePoints = append(linePoints, typeName, utils.GetPointsFromSlice(v))
+			}
+			// draw chart
+			chartFileName := fmt.Sprintf("%s-case%d-%s-%d-%d", nfs.GetName(), caseIndex, schedulerName,
+				testCase.NumPodsPerNode, testCase.AllocatePercentage)
+			chart := &utils.Chart{
+				Title:      "Node Fairness",
+				XLabel:     "Seconds",
+				YLabel:     "Number of Nodes",
+				Width:      constants.ChartWidth,
+				Height:     constants.ChartHeight,
+				LinePoints: linePoints,
+				SvgFile:    nfs.commonConf.OutputPath + "/" + chartFileName + constants.ChartFileSuffix,
+			}
+			err = utils.DrawChart(chart)
+			outputName := "output node distribution timeline chart"
+			if err != nil {
+				schedulerVerification.AddSubVerification(outputName,
+					fmt.Sprintf("failed to draw chart: %s", err.Error()),
+					utils.FAILED)
+				return
+			}
+			schedulerVerification.AddSubVerification(outputName, chart.SvgFile, utils.SUCCEEDED)
+
+			// delete this app and wait for it to be cleaned up
+			utils.Logger.Info("delete this app then wait for it to be cleaned up",
+				zap.String("appID", appInfo.AppID))
+			err = appManager.DeleteWait(appInfo, maxWaitTime)
+			if err != nil {
+				utils.Logger.Error("failed to delete/wait app", zap.Error(err))
+				schedulerVerification.AddSubVerification("cleanup app", err.Error(), utils.FAILED)
+				return
+			}
+		}
+	}
+}
+
+func parseTableFromNodeDistribution(nodeDistribution [10][]int) *utils.Table {
+	var data [][]string
+	for bucketIndex, bucketData := range nodeDistribution {
+		rowData := make([]string, len(bucketData)+1)
+		rowData[0] = fmt.Sprintf("bucket-%d", bucketIndex)
+		for i, dataItem := range bucketData {
+			rowData[i+1] = strconv.Itoa(dataItem)
+		}
+		data = append(data, rowData)
+	}
+	headers := make([]string, len(nodeDistribution[0])+1)
+	headers[0] = "buckets"
+	for i := 0; i < len(nodeDistribution[0]); i++ {
+		headers[i+1] = strconv.Itoa(i)
+	}
+	return &utils.Table{
+		Headers: headers,
+		Data:    data,
+	}
+}

--- a/perf-tools/scenarios/throughput.go
+++ b/perf-tools/scenarios/throughput.go
@@ -1,0 +1,169 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package scenarios
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/apache/incubator-yunikorn-release/perf-tools/constants"
+	"github.com/apache/incubator-yunikorn-release/perf-tools/framework"
+	"github.com/apache/incubator-yunikorn-release/perf-tools/utils"
+	"go.uber.org/zap"
+)
+
+const ThroughputScenarioName = "throughput"
+
+type ThroughputScenario struct {
+	kubeClient   *utils.KubeClient
+	commonConf   *framework.CommonConfig
+	scenarioConf *ThroughputScenarioConfig
+}
+
+type ThroughputScenarioConfig struct {
+	CleanUpDelayMs int
+	SchedulerNames []string
+	Cases          []*ThroughputCaseConfig
+}
+
+type ThroughputCaseConfig struct {
+	Description    string
+	RequestConfigs []*RequestConfig
+}
+
+func init() {
+	framework.Register(&ThroughputScenario{})
+}
+
+func (ts *ThroughputScenario) GetName() string {
+	return ThroughputScenarioName
+}
+
+func (ts *ThroughputScenario) Init(kubeClient *utils.KubeClient, conf *framework.Config) error {
+	ts.kubeClient = kubeClient
+	ts.commonConf = conf.Common
+	ts.scenarioConf = &ThroughputScenarioConfig{}
+	return LoadScenarioConf(conf, ts.GetName(), ts.scenarioConf)
+}
+
+func (ts *ThroughputScenario) Run(results *utils.Results) {
+	scenarioResults := results.CreateScenarioResults(ts.GetName())
+	schedulerNames := ts.scenarioConf.SchedulerNames
+	maxWaitTime := time.Duration(ts.commonConf.MaxWaitSeconds) * time.Second
+	var appManager framework.AppManager
+	var appInfo *framework.AppInfo
+	var appAnanyzer *framework.AppAnalyzer
+	// make sure app is cleaned up when error occurred
+	defer func() {
+		CleanupApp(appManager, appInfo, maxWaitTime)
+	}()
+
+	for caseIndex, testCase := range ts.scenarioConf.Cases {
+		verGroupName := fmt.Sprintf("Case-%d", caseIndex)
+		verGroupDescription := fmt.Sprintf("%+v", testCase.Description)
+		caseVerification := scenarioResults.AddVerificationGroup(verGroupName, verGroupDescription)
+		utils.Logger.Info("[Prepare] add verification group", zap.String("name", verGroupName),
+			zap.String("description", verGroupDescription))
+		// init app info & app manager
+		requestInfos := ConvertToRequestInfos(testCase.RequestConfigs)
+		appInfo = framework.NewAppInfo(ts.commonConf.Namespace, ThroughputScenarioName, ts.commonConf.Queue,
+			requestInfos, ts.commonConf.PodTemplateSpec, ts.commonConf.PodSpec)
+		appManager = framework.NewDeploymentsAppManager(ts.kubeClient)
+		appAnanyzer = framework.NewAppAnalyzer(appInfo)
+
+		// test for different schedulers
+		cumulativeDistributions := make(map[string][]int, len(schedulerNames))
+		for _, schedulerName := range schedulerNames {
+			utils.Logger.Info("start testing for scheduler " + schedulerName)
+			schedulerVerification := caseVerification.AddSubVerificationGroup(
+				fmt.Sprintf("test for %s", schedulerName), verGroupDescription)
+
+			// create app and wait for it to be running
+			utils.Logger.Info("[Testing] create an app and wait for it to be running, refresh app status at last",
+				zap.String("appID", appInfo.AppID))
+			beginTime := time.Now().Truncate(time.Second)
+			err := appManager.CreateWaitAndRefreshTasksStatus(schedulerName, appInfo, maxWaitTime)
+			if err != nil {
+				utils.Logger.Error("failed to create/wait/refresh app", zap.Error(err))
+				schedulerVerification.AddSubVerification("test app", err.Error(), utils.FAILED)
+				return
+			}
+			utils.Logger.Info("all requirements of this app are satisfied",
+				zap.String("appID", appInfo.AppID),
+				zap.Duration("elapseTime", time.Since(beginTime)))
+
+			// calculate scheduled time distribution and its cumulative distribution
+			scheduledTimeDistribution := appAnanyzer.GetTimeDistribution(framework.PodScheduled)
+			cumulativeDistributions[schedulerName] = getCumulativeDistribution(scheduledTimeDistribution)
+
+			if ts.scenarioConf.CleanUpDelayMs > 0 {
+				utils.Logger.Info("wait for a while before cleaning up test apps",
+					zap.String("schedulerName", schedulerName),
+					zap.Any("cleanUpDelayMs", ts.scenarioConf.CleanUpDelayMs))
+				time.Sleep(time.Millisecond * time.Duration(ts.scenarioConf.CleanUpDelayMs))
+			}
+
+			// delete this app and wait for it to be cleaned up
+			utils.Logger.Info("[Cleanup] delete this app then wait for it to be cleaned up",
+				zap.String("appID", appInfo.AppID))
+			err = appManager.DeleteWait(appInfo, maxWaitTime)
+			if err != nil {
+				utils.Logger.Error("failed to delete/wait app", zap.Error(err))
+				schedulerVerification.AddSubVerification("cleanup app", err.Error(), utils.FAILED)
+				return
+			}
+
+			description := fmt.Sprintf("seconds: %d, throughputDistribution: %+v",
+				len(scheduledTimeDistribution), scheduledTimeDistribution)
+			schedulerVerification.AddSubVerification("get scheduled time distribution", description, utils.SUCCEEDED)
+		}
+		// draw chart
+		linePoints := utils.GetLinePoints(cumulativeDistributions)
+		chartFileName := fmt.Sprintf("%s-case%d-%d", ThroughputScenarioName,
+			caseIndex, appInfo.GetDesiredNumTasks())
+		chart := &utils.Chart{
+			Title:      "Scheduling Throughput",
+			XLabel:     "Seconds",
+			YLabel:     "Number of Scheduled Pods",
+			Width:      constants.ChartWidth,
+			Height:     constants.ChartHeight,
+			LinePoints: linePoints,
+			SvgFile:    ts.commonConf.OutputPath + "/" + chartFileName + constants.ChartFileSuffix,
+		}
+		err := utils.DrawChart(chart)
+		outputName := "output chart"
+		if err != nil {
+			caseVerification.AddSubVerification(outputName,
+				fmt.Sprintf("failed to draw chart: %s", err.Error()),
+				utils.FAILED)
+			return
+		}
+		caseVerification.AddSubVerification(outputName, chart.SvgFile, utils.SUCCEEDED)
+	}
+}
+
+func getCumulativeDistribution(data []int) []int {
+	cumulativeDistribution := make([]int, len(data))
+	cumulativeNum := 0
+	for i := range data {
+		cumulativeNum += data[i]
+		cumulativeDistribution[i] = cumulativeNum
+	}
+	return cumulativeDistribution
+}

--- a/perf-tools/utils/chart.go
+++ b/perf-tools/utils/chart.go
@@ -1,0 +1,71 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package utils
+
+import (
+	"go.uber.org/zap"
+	"gonum.org/v1/plot"
+	"gonum.org/v1/plot/plotter"
+	"gonum.org/v1/plot/plotutil"
+	"gonum.org/v1/plot/vg"
+)
+
+type Chart struct {
+	Title      string
+	XLabel     string
+	YLabel     string
+	Width      vg.Length
+	Height     vg.Length
+	LinePoints []interface{}
+	SvgFile    string
+}
+
+func DrawChart(chart *Chart) error {
+	p := plot.New()
+	p.Title.Text = chart.Title
+	p.X.Label.Text = chart.XLabel
+	p.Y.Label.Text = chart.YLabel
+	err := plotutil.AddLinePoints(p, chart.LinePoints...)
+	if err != nil {
+		return err
+	}
+	if err := p.Save(chart.Width, chart.Height, chart.SvgFile); err != nil {
+		return err
+	}
+	Logger.Info("Successfully draw chart", zap.String("title", chart.Title),
+		zap.String("outputFile", chart.SvgFile))
+	return nil
+}
+
+func GetPointsFromSlice(slice []int) plotter.XYs {
+	pts := make(plotter.XYs, len(slice))
+	for i := range slice {
+		pts[i].X = float64(i)
+		pts[i].Y = float64(slice[i])
+	}
+	return pts
+}
+
+func GetLinePoints(dataMap map[string][]int) []interface{} {
+	var linePoints []interface{}
+	for k, v := range dataMap {
+		linePoints = append(linePoints, k, GetPointsFromSlice(v))
+	}
+	return linePoints
+}

--- a/perf-tools/utils/kubeclient.go
+++ b/perf-tools/utils/kubeclient.go
@@ -1,0 +1,121 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"k8s.io/client-go/tools/clientcmd"
+
+	"go.uber.org/zap"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type KubeClient struct {
+	clientSet *kubernetes.Clientset
+	configs   *rest.Config
+}
+
+func NewKubeClient(KubeConfigFile string) (*KubeClient, error) {
+	kubeConfigFile := os.ExpandEnv(KubeConfigFile)
+	fmt.Println(KubeConfigFile)
+	if kubeConfigFile == "" {
+		return nil, fmt.Errorf("specified kubeconfig file %s not found", kubeConfigFile)
+	}
+	restClientConfig, err := clientcmd.BuildConfigFromFlags("", kubeConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	configuredClient := kubernetes.NewForConfigOrDie(restClientConfig)
+	return &KubeClient{
+		clientSet: configuredClient,
+		configs:   restClientConfig,
+	}, nil
+}
+
+func GetListOptions(selectLabels map[string]string) *metav1.ListOptions {
+	labelSelector := metav1.LabelSelector{MatchLabels: selectLabels}
+	return &metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+	}
+}
+
+func GetEverythingListOptions() *metav1.ListOptions {
+	return &metav1.ListOptions{LabelSelector: labels.Everything().String()}
+}
+
+func (kc *KubeClient) GetPods(namespace string, listOptions *metav1.ListOptions) (*apiv1.PodList, error) {
+	return kc.clientSet.CoreV1().Pods(namespace).List(context.TODO(), *listOptions)
+}
+
+func (kc *KubeClient) GetNodes(listOptions *metav1.ListOptions) (*apiv1.NodeList, error) {
+	return kc.clientSet.CoreV1().Nodes().List(context.TODO(), *listOptions)
+}
+
+func (kc *KubeClient) GetConfigMap(namespace string, name string, getOptions *metav1.GetOptions) (*apiv1.ConfigMap, error) {
+	return kc.clientSet.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, *getOptions)
+}
+
+func (kc *KubeClient) CreateDeployment(namespace string, deployment *appsv1.Deployment) error {
+	deploymentsClient := kc.clientSet.AppsV1().Deployments(namespace)
+	Logger.Debug("creating deployment...")
+	result, err := deploymentsClient.Create(context.TODO(), deployment, metav1.CreateOptions{})
+	Logger.Debug("created deployment", zap.String("deploymentName", result.GetObjectMeta().GetName()))
+	return err
+}
+
+func (kc *KubeClient) GetDeployment(namespace, name string) (*appsv1.Deployment, error) {
+	deploymentsClient := kc.clientSet.AppsV1().Deployments(namespace)
+	return deploymentsClient.Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (kc *KubeClient) DeleteDeployment(namespace, name string) error {
+	deploymentsClient := kc.clientSet.AppsV1().Deployments(namespace)
+	deletePolicy := metav1.DeletePropagationForeground
+	return deploymentsClient.Delete(context.TODO(), name, metav1.DeleteOptions{
+		PropagationPolicy: &deletePolicy,
+	})
+}
+
+// GetDeploymentInfo return basic information of deployment: (createTime, [desired, created, ready] replicas, error)
+func (kc *KubeClient) GetDeploymentInfo(namespace, appID string) (time.Time, []int, error) {
+	deployment, err := kc.GetDeployment(namespace, appID)
+	if err != nil || deployment == nil {
+		return time.Time{}, nil, err
+	}
+	return deployment.CreationTimestamp.Time, []int{int(*deployment.Spec.Replicas), int(deployment.Status.Replicas),
+		int(deployment.Status.ReadyReplicas)}, nil
+}
+
+func (kc *KubeClient) GetConfigs() *rest.Config {
+	return kc.configs
+}
+
+func (kc *KubeClient) GetClientSet() *kubernetes.Clientset {
+	return kc.clientSet
+}

--- a/perf-tools/utils/log.go
+++ b/perf-tools/utils/log.go
@@ -1,0 +1,36 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package utils
+
+import (
+	"go.uber.org/zap/zapcore"
+
+	"github.com/apache/incubator-yunikorn-core/pkg/log"
+	"go.uber.org/zap"
+)
+
+var Logger *zap.Logger
+
+func init() {
+	Logger = log.Logger()
+}
+
+func SetLogLevel(level int) {
+	log.InitAndSetLevel(zapcore.Level(level))
+}

--- a/perf-tools/utils/output.go
+++ b/perf-tools/utils/output.go
@@ -1,0 +1,223 @@
+package utils
+
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import (
+	"fmt"
+	"strings"
+)
+
+type VerificationStatus int
+
+const (
+	SUCCEEDED VerificationStatus = iota
+	FAILED
+)
+
+type Reporter interface {
+	GenerateReport()
+}
+
+type Results struct {
+	ScenarioResults []*ScenarioResult
+}
+
+type ScenarioResult struct {
+	Name          string
+	Status        VerificationStatus
+	Verifications []*Verification
+}
+
+type Verification struct {
+	Deep             int
+	Name             string
+	Status           VerificationStatus
+	Description      string
+	SubVerifications []*Verification
+	Parent           *Verification
+}
+
+func NewResults() *Results {
+	return &Results{
+		ScenarioResults: make([]*ScenarioResult, 0),
+	}
+}
+
+func (r *Results) CreateScenarioResults(scenarioName string) *ScenarioResult {
+	scenarioResult := &ScenarioResult{
+		Name:          scenarioName,
+		Status:        SUCCEEDED,
+		Verifications: make([]*Verification, 0),
+	}
+	r.ScenarioResults = append(r.ScenarioResults, scenarioResult)
+	return scenarioResult
+}
+
+func (sr *ScenarioResult) AddVerification(name, description string, status VerificationStatus) {
+	verification := &Verification{
+		Deep:        1,
+		Name:        name,
+		Description: description,
+		Status:      status,
+	}
+	sr.Verifications = append(sr.Verifications, verification)
+	if status == FAILED {
+		sr.Status = FAILED
+	}
+}
+
+func (sr *ScenarioResult) AddVerificationGroup(name, description string) *Verification {
+	verification := &Verification{
+		Deep:             1,
+		Name:             name,
+		Description:      description,
+		SubVerifications: make([]*Verification, 0),
+	}
+	sr.Verifications = append(sr.Verifications, verification)
+	return verification
+}
+
+func (vg *Verification) AddSubVerificationGroup(name, description string) *Verification {
+	subVerification := &Verification{
+		Deep:        vg.Deep + 1,
+		Name:        name,
+		Description: description,
+		Parent:      vg,
+	}
+	vg.SubVerifications = append(vg.SubVerifications, subVerification)
+	return subVerification
+}
+
+func (vg *Verification) AddAssertSubVerification(result bool, name, description string) *Verification {
+	var status VerificationStatus
+	if result {
+		status = SUCCEEDED
+	} else {
+		status = FAILED
+	}
+	return vg.AddSubVerification(name, description, status)
+}
+
+func (vg *Verification) AddErrorSubVerification(err error, name, description string) *Verification {
+	var status VerificationStatus
+	if err == nil {
+		status = SUCCEEDED
+	} else {
+		status = FAILED
+		if description != "" {
+			description += ","
+		}
+		description += " err: " + strings.TrimSpace(err.Error())
+	}
+	return vg.AddSubVerification(name, description, status)
+}
+
+func (vg *Verification) AddSubVerification(name, description string, status VerificationStatus) *Verification {
+	subVerification := &Verification{
+		Deep:        vg.Deep + 1,
+		Name:        name,
+		Status:      status,
+		Description: description,
+		Parent:      vg,
+	}
+	vg.SubVerifications = append(vg.SubVerifications, subVerification)
+	if status == FAILED {
+		parentVer := subVerification.Parent
+		for parentVer != nil {
+			parentVer.Status = FAILED
+			parentVer = parentVer.Parent
+		}
+	}
+	//Logger.Info(getVerificationStatusInfo(subVerification))
+	return subVerification
+}
+
+func (vg *Verification) IsFailed() bool {
+	return vg.Status == FAILED
+}
+
+func (r *Results) RefreshStatus() {
+	for _, scenarioResult := range r.ScenarioResults {
+		status := SUCCEEDED
+		for _, v := range scenarioResult.Verifications {
+			v.RefreshStatus()
+			if v.Status == FAILED {
+				status = FAILED
+			}
+		}
+		scenarioResult.Status = status
+	}
+}
+
+func (v *Verification) RefreshStatus() {
+	if len(v.SubVerifications) > 0 {
+		status := SUCCEEDED
+		for _, subV := range v.SubVerifications {
+			subV.RefreshStatus()
+			if subV.Status == FAILED {
+				status = FAILED
+			}
+		}
+		v.Status = status
+	}
+}
+
+func (r *Results) String() string {
+	outputInfo := ""
+	for _, scenarioResult := range r.ScenarioResults {
+		outputInfo += fmt.Sprintf("%s\n", getStatusInfo("Scenario: "+scenarioResult.Name, scenarioResult.Status))
+		for _, v := range scenarioResult.Verifications {
+			outputInfo += v.String()
+		}
+	}
+	return outputInfo
+}
+
+func (v *Verification) String() string {
+	outputInfo := fmt.Sprintf("%s%s\n", getDeepPrefix(v.Deep), getVerificationStatusInfo(v))
+	if len(v.SubVerifications) > 0 {
+		for _, subV := range v.SubVerifications {
+			outputInfo += subV.String()
+		}
+	}
+	return outputInfo
+}
+
+func getStatusInfo(name string, status VerificationStatus) string {
+	statusStr := ""
+	switch status {
+	case FAILED:
+		statusStr = "FAILED"
+	case SUCCEEDED:
+		statusStr = "SUCCEEDED"
+	}
+	return fmt.Sprintf("%s [%s]", name, statusStr)
+}
+
+func getVerificationStatusInfo(v *Verification) string {
+	statusInfo := getStatusInfo(v.Name, v.Status)
+	if v.Description != "" {
+		statusInfo += fmt.Sprintf(" (%s)", v.Description)
+	}
+	return statusInfo
+}
+
+func getDeepPrefix(deep int) string {
+	return strings.Repeat("    ", deep)
+}

--- a/perf-tools/utils/output_test.go
+++ b/perf-tools/utils/output_test.go
@@ -1,0 +1,54 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestResults(t *testing.T) {
+	results := NewResults()
+	s1 := results.CreateScenarioResults("s1")
+	s1.AddVerification("s1-v1", "des...", SUCCEEDED)
+	s2 := results.CreateScenarioResults("s2")
+	s2.AddVerification("s2-v1", "des...", SUCCEEDED)
+	s2.AddVerification("s2-v2", "des...", SUCCEEDED)
+	s2vg1 := s2.AddVerificationGroup("s2-vg1", "")
+	s2vg1.AddSubVerification("s2-vg1-1", "des...", SUCCEEDED)
+	s2vg1.AddSubVerification("s2-vg1-2", "des...", SUCCEEDED)
+	s2vg2 := s2.AddVerificationGroup("s2-vg2", "")
+	s2vg2.AddSubVerification("s2-vg2-1", "des...", SUCCEEDED)
+	s2vg2.AddSubVerification("s2-vg2-2", "des...", FAILED)
+	s2vg2.AddSubVerification("s2-vg2-3", "des...", SUCCEEDED)
+	s3 := results.CreateScenarioResults("s3")
+	s3vg1 := s3.AddVerificationGroup("s3-vg1", "")
+	s3vg1sub1 := s3vg1.AddSubVerificationGroup("s3-vg1-1", "")
+	s3vg1sub1.AddSubVerification("s3-vg1-1-1", "", FAILED)
+
+	results.RefreshStatus()
+	assert.Equal(t, s2vg2.Status, FAILED)
+	assert.Equal(t, s2.Status, FAILED)
+	assert.Equal(t, s3.Status, FAILED)
+	assert.Equal(t, s3vg1.Status, FAILED)
+	assert.Equal(t, s3vg1sub1.Status, FAILED)
+
+	t.Log("\n" + results.String())
+}

--- a/perf-tools/utils/table.go
+++ b/perf-tools/utils/table.go
@@ -1,0 +1,54 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+type Table struct {
+	Headers []string
+	Data    [][]string
+}
+
+// https://pkg.go.dev/github.com/olekukonko/tablewriter
+func (t *Table) Print() {
+	writer := tablewriter.NewWriter(os.Stdout)
+	t.render(writer)
+}
+
+func (t *Table) Output(file string) error {
+	f, err := os.Create(file)
+	if err != nil {
+		return err
+	}
+	writer := tablewriter.NewWriter(f)
+	t.render(writer)
+	return nil
+}
+
+func (t *Table) render(writer *tablewriter.Table) {
+	writer.SetHeader(t.Headers)
+	for _, v := range t.Data {
+		writer.Append(v)
+	}
+	writer.Render()
+}


### PR DESCRIPTION
Now it contains 3 common test cases which are applicable for any schedulers:
(1) throughput test scenario compares the scheduling throughput among multiple schedulers, generates a comparison chart for multiple schedulers in each case.
(2) e2e_perf test scenario can give reports with slowest tasks, node distributions, time and QPS statistics on different pod stages from PodCreated to ContainersReady.
(3) node_fairness test scenario requests a certain number of pods via different schedulers and then record the distributions of node usage, draw results on charts separately for different schedulers at last.

You can built it with the make file "perf-tools/Makefile", a binary package will be generated in "perf-tools/target" directory after executing build command like this:  make build GOOS=Linux GOARCH=amd64
Then you can modify the cases in conf.yaml and perform tests with simple command:  perf-tools -scenarios throughput,node_fairness,e2e_perf