### PR TITLE
[YUNIKORN-1008] Allow admission controller to bypass pods in certain namespaces

### DIFF
--- a/helm-charts/yunikorn/README.md
+++ b/helm-charts/yunikorn/README.md
@@ -57,28 +57,29 @@ helm install yunikorn yunikorn/yunikorn
 ## Configuration
 The following table lists the configurable parameters of the YuniKorn chart and their default values.
 
-| Parameter                            | Description                                              | Default                                     |
-| ---                                  | ---                                                      | ---                                         |
-| `imagePullSecrets`                   | Docker repository secrets                                | ` `  
-| `serviceAccount`                     | Service account name                                     | `yunikorn-admin`  
-| `image.repository`                   | Scheduler image repository                               | `apache/yunikorn` 
-| `image.tag`                          | Scheduler image tag                                      | `scheduler-latest` 
-| `image.pullPolicy`                   | Scheduler image pull policy                              | `Always`  
-| `webImage.repository`                | web app image repository                                 | `apache/yunikorn` 
-| `webImage.tag`                       | web app image tag                                        | `web-latest` 
-| `webImage.pullPolicy`                | web app image pull policy                                | `Always`  
-| `admissionControllerImage.repository`| admission controller image repository                    | `apache/yunikorn` 
-| `admissionControllerImage.tag`       | admission controller image tag                           | `admission-latest` 
-| `admissionControllerImage.pullPolicy`| admission controller image pull policy                   | `Always`  
-| `service.port`                       | Port of the scheduler service                            | `9080` 
-| `service.portWeb`                    | Port of the web application service                      | `9889`  
-| `resources.requests.cpu`             | CPU resource requests                                    | `200m`  
-| `resources.requests.memory`          | Memory resource requests                                 | `1Gi`  
-| `resources.limits.cpu`               | CPU resource limit                                       | `4`  
-| `resources.limits.memory`            | Memory resource limit                                    | `2Gi` 
-| `embedAdmissionController`           | Flag for enabling/disabling the admission controller     | `true`
-| `operatorPlugins`                    | Scheduler operator plugins                               | `general` 
-| `nodeSelector`                       | Scheduler deployment nodeSelector(s)                     | ` `      
+| Parameter                              | Description                                            | Default                                     |
+| ---                                    | ---                                                    | ---                                         |
+| `imagePullSecrets`                     | Docker repository secrets                              | ` `
+| `serviceAccount`                       | Service account name                                   | `yunikorn-admin`
+| `image.repository`                     | Scheduler image repository                             | `apache/yunikorn`
+| `image.tag`                            | Scheduler image tag                                    | `scheduler-latest`
+| `image.pullPolicy`                     | Scheduler image pull policy                            | `Always`
+| `webImage.repository`                  | Web app image repository                               | `apache/yunikorn`
+| `webImage.tag`                         | Web app image tag                                      | `web-latest`
+| `webImage.pullPolicy`                  | Web app image pull policy                              | `Always`
+| `admissionControllerImage.repository`  | Admission controller image repository                  | `apache/yunikorn`
+| `admissionControllerImage.tag`         | Admission controller image tag                         | `admission-latest`
+| `admissionControllerImage.pullPolicy`  | Admission controller image pull policy                 | `Always`
+| `admissionControllerNamespaceBlacklist`| Comma-separated list of namespace regexes to ignore    | `^kube-system$`
+| `service.port`                         | Port of the scheduler service                          | `9080`
+| `service.portWeb`                      | Port of the web application service                    | `9889`
+| `resources.requests.cpu`               | CPU resource requests                                  | `200m`
+| `resources.requests.memory`            | Memory resource requests                               | `1Gi`
+| `resources.limits.cpu`                 | CPU resource limit                                     | `4`
+| `resources.limits.memory`              | Memory resource limit                                  | `2Gi`
+| `embedAdmissionController`             | Flag for enabling/disabling the admission controlle    | `true`
+| `operatorPlugins`                      | Scheduler operator plugins                             | `general`
+| `nodeSelector`                         | Scheduler deployment nodeSelector(s)                   | ` `
 
 These parameters can be passed in via helm's `--set` option, such as `--set embedAdmissionController=false`.
 

--- a/helm-charts/yunikorn/templates/admission-controller-deployment.yaml
+++ b/helm-charts/yunikorn/templates/admission-controller-deployment.yaml
@@ -61,6 +61,8 @@ spec:
             value: queues
           - name: ADMISSION_CONTROLLER_SERVICE
             value: yunikorn-admission-controller-service
+          - name: ADMISSION_CONTROLLER_NAMESPACE_BLACKLIST
+            value: "{{ .Values.admissionControllerNamespaceBlacklist }}"
           - name: SCHEDULER_SERVICE_ADDRESS
             value: "yunikorn-service:9080"
           - name: ENABLE_CONFIG_HOT_REFRESH

--- a/helm-charts/yunikorn/values.yaml
+++ b/helm-charts/yunikorn/values.yaml
@@ -29,6 +29,8 @@ operatorPlugins: "general"
 serviceAccount: yunikorn-admin
 admissionControllerServiceAccount: yunikorn-admission-controller
 
+admissionControllerNamespaceBlacklist: "^kube-system$"
+
 image:
   repository: apache/yunikorn
   tag: scheduler-latest


### PR DESCRIPTION
# Description
This is the helm changes required to customize the admission controller with blacklisted namespaces.

# JIRA issue
https://issues.apache.org/jira/browse/YUNIKORN-1008


