### PR TITLE
[YUNIKORN-1057] Add helm setting to deploy scheduler in plugin mode

### DIFF
--- a/helm-charts/yunikorn/README.md
+++ b/helm-charts/yunikorn/README.md
@@ -66,6 +66,9 @@ The following table lists the configurable parameters of the YuniKorn chart and 
 | `image.repository`                     | Scheduler image repository                             | `apache/yunikorn`
 | `image.tag`                            | Scheduler image tag                                    | `scheduler-latest`
 | `image.pullPolicy`                     | Scheduler image pull policy                            | `Always`
+| `pluginImage.repository`               | Scheduler plugin image repository                      | `apache/yunikorn`
+| `pluginImage.tag`                      | Scheduler plugin image tag                             | `scheduler-plugin-latest`
+| `pluginImage.pullPolicy`               | Scheduler plugin image pull policy                     | `Always`
 | `webImage.repository`                  | Web app image repository                               | `apache/yunikorn`
 | `webImage.tag`                         | Web app image tag                                      | `web-latest`
 | `webImage.pullPolicy`                  | Web app image pull policy                              | `Always`

--- a/helm-charts/yunikorn/README.md
+++ b/helm-charts/yunikorn/README.md
@@ -79,7 +79,8 @@ The following table lists the configurable parameters of the YuniKorn chart and 
 | `resources.requests.memory`            | Memory resource requests                               | `1Gi`
 | `resources.limits.cpu`                 | CPU resource limit                                     | `4`
 | `resources.limits.memory`              | Memory resource limit                                  | `2Gi`
-| `embedAdmissionController`             | Flag for enabling/disabling the admission controlle    | `true`
+| `embedAdmissionController`             | Flag for enabling/disabling the admission controller   | `true`
+| `enableSchedulerPlugin`                | Flag for enabling/disabling scheduler plugin mode      | `false`
 | `operatorPlugins`                      | Scheduler operator plugins                             | `general`
 | `nodeSelector`                         | Scheduler deployment nodeSelector(s)                   | ` `
 

--- a/helm-charts/yunikorn/templates/deployment.yaml
+++ b/helm-charts/yunikorn/templates/deployment.yaml
@@ -51,8 +51,13 @@ spec:
       {{- end }}
       containers:
         - name: yunikorn-scheduler-k8s
+      {{- if .Values.enableSchedulerPlugin }}
+          image: "{{ .Values.pluginImage.repository }}:{{ .Values.pluginImage.tag }}"
+          imagePullPolicy: {{ .Values.pluginImage.pullPolicy }}
+      {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+      {{- end }}
           ports:
             - name: http1
               containerPort: {{ .Values.service.port }}

--- a/helm-charts/yunikorn/values.yaml
+++ b/helm-charts/yunikorn/values.yaml
@@ -36,6 +36,11 @@ image:
   tag: scheduler-latest
   pullPolicy: Always
 
+pluginImage:
+  repository: apache/yunikorn
+  tag: scheduler-plugin-latest
+  pullPolicy: Always
+
 admissionControllerImage:
   repository: apache/yunikorn
   tag: admission-latest
@@ -63,6 +68,10 @@ resources:
 # When this flag is false, the admission controller will not be installed.
 # Once the admission controller is installed, all traffic will be routing to yunikorn.
 embedAdmissionController: true
+
+# When this flag is true, the scheduler will be deployed as Kubernetes scheduler plugin.
+# When this flag is false, the scheduler will be deployed as a standalone scheduler.
+enableSchedulerPlugin: false
 
 #
 # ------------------------------------------------------------------------


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/YUNIKORN-1057

This adds a new `enableSchedulerPlugin` variable to the helm chart to allow deploying the scheduler in plugin mode.
