### PR TITLE
[YUNIKORN-1078] Add more parameters in helm chart

### DIFF
--- a/helm-charts/yunikorn/README.md
+++ b/helm-charts/yunikorn/README.md
@@ -41,14 +41,14 @@ YuniKorn can be deployed with [helm-charts](https://hub.helm.sh/charts/yunikorn/
 
 ## Supported K8s versions 
 
-| K8s Version   | Support?  |
-| ------------- |:-------------:|
-| 1.18.x (or earlier) | X |
-| 1.19.x | End-of-life; Untested |
-| 1.20.x | √ |
-| 1.21.x | √ |
-| 1.22.x | √ |
-| 1.23.x | √ |
+| K8s Version         |       Support?        |
+| ------------------- | :-------------------: |
+| 1.18.x (or earlier) |           X           |
+| 1.19.x              | End-of-life; Untested |
+| 1.20.x              |           √           |
+| 1.21.x              |           √           |
+| 1.22.x              |           √           |
+| 1.23.x              |           √           |
 
 ## Installing the chart
 ```
@@ -59,33 +59,48 @@ helm install yunikorn yunikorn/yunikorn
 ## Configuration
 The following table lists the configurable parameters of the YuniKorn chart and their default values.
 
-| Parameter                              | Description                                            | Default                                     |
-| ---                                    | ---                                                    | ---                                         |
-| `imagePullSecrets`                     | Docker repository secrets                              | ` `
-| `serviceAccount`                       | Service account name                                   | `yunikorn-admin`
-| `image.repository`                     | Scheduler image repository                             | `apache/yunikorn`
-| `image.tag`                            | Scheduler image tag                                    | `scheduler-latest`
-| `image.pullPolicy`                     | Scheduler image pull policy                            | `Always`
-| `pluginImage.repository`               | Scheduler plugin image repository                      | `apache/yunikorn`
-| `pluginImage.tag`                      | Scheduler plugin image tag                             | `scheduler-plugin-latest`
-| `pluginImage.pullPolicy`               | Scheduler plugin image pull policy                     | `Always`
-| `webImage.repository`                  | Web app image repository                               | `apache/yunikorn`
-| `webImage.tag`                         | Web app image tag                                      | `web-latest`
-| `webImage.pullPolicy`                  | Web app image pull policy                              | `Always`
-| `admissionControllerImage.repository`  | Admission controller image repository                  | `apache/yunikorn`
-| `admissionControllerImage.tag`         | Admission controller image tag                         | `admission-latest`
-| `admissionControllerImage.pullPolicy`  | Admission controller image pull policy                 | `Always`
-| `admissionControllerNamespaceBlacklist`| Comma-separated list of namespace regexes to ignore    | `^kube-system$`
-| `service.port`                         | Port of the scheduler service                          | `9080`
-| `service.portWeb`                      | Port of the web application service                    | `9889`
-| `resources.requests.cpu`               | CPU resource requests                                  | `200m`
-| `resources.requests.memory`            | Memory resource requests                               | `1Gi`
-| `resources.limits.cpu`                 | CPU resource limit                                     | `4`
-| `resources.limits.memory`              | Memory resource limit                                  | `2Gi`
-| `embedAdmissionController`             | Flag for enabling/disabling the admission controller   | `true`
-| `enableSchedulerPlugin`                | Flag for enabling/disabling scheduler plugin mode      | `false`
-| `operatorPlugins`                      | Scheduler operator plugins                             | `general`
-| `nodeSelector`                         | Scheduler deployment nodeSelector(s)                   | ` `
+| Parameter                                       | Description                                          | Default                         |
+| ----------------------------------------------- | ---------------------------------------------------- | ------------------------------- |
+| `imagePullSecrets`                              | Docker repository secrets                            | ` `                             |
+| `serviceAccount`                                | Service account name                                 | `yunikorn-admin`                |
+| `image.repository`                              | Scheduler image repository                           | `apache/yunikorn`               |
+| `image.tag`                                     | Scheduler image tag                                  | `scheduler-latest`              |
+| `image.pullPolicy`                              | Scheduler image pull policy                          | `Always`                        |
+| `pluginImage.repository`                        | Scheduler plugin image repository                    | `apache/yunikorn`               |
+| `pluginImage.tag`                               | Scheduler plugin image tag                           | `scheduler-plugin-latest`       |
+| `pluginImage.pullPolicy`                        | Scheduler plugin image pull policy                   | `Always`                        |
+| `webImage.repository`                           | Web app image repository                             | `apache/yunikorn`               |
+| `webImage.tag`                                  | Web app image tag                                    | `web-latest`                    |
+| `webImage.pullPolicy`                           | Web app image pull policy                            | `Always`                        |
+| `admissionController.image.replicaCount`        | Admission controller image repository                | `1`                             |
+| `admissionController.serviceAccount`            | Admission controller service account name            | `yunikorn-admission-controller` |
+| `admissionController.image.repository`          | Admission controller image repository                | `apache/yunikorn`               |
+| `admissionController.image.tag`                 | Admission controller image tag                       | `admission-latest`              |
+| `admissionController.image.pullPolicy`          | Admission controller image pull policy               | `Always`                        |
+| `admissionController.namespaceBlacklist`        | Comma-separated list of namespace regexes to ignore  | `^kube-system$`                 |
+| `admissionController.resources.requests.cpu`    | Admission controller CPU resource requests           | `100m`                          |
+| `admissionController.resources.requests.memory` | Admission controller memory resource requests        | `500Mi`                         |
+| `admissionController.resources.limits.cpu`      | Admission controller CPU resource limit              | `500m`                          |
+| `admissionController.resources.limits.memory`   | Admission controller memory resource limit           | `500Mi`                         |
+| `admissionController.nodeSelector`              | Admission controller deployment nodeSelector(s)      | `{}`                            |
+| `admissionController.tolerations`               | Admission controller deployment tolerations          | `[]`                            |
+| `admissionController.affinity`                  | Admission controller deployment affinity             | `{}`                            |
+| `service.port`                                  | Port of the scheduler service                        | `9080`                          |
+| `service.portWeb`                               | Port of the web application service                  | `9889`                          |
+| `resources.requests.cpu`                        | CPU resource requests                                | `200m`                          |
+| `resources.requests.memory`                     | Memory resource requests                             | `1Gi`                           |
+| `resources.limits.cpu`                          | CPU resource limit                                   | `4`                             |
+| `resources.limits.memory`                       | Memory resource limit                                | `2Gi`                           |
+| `webResources.requests.cpu`                     | Web app CPU resource requests                        | `100m`                          |
+| `webResources.requests.memory`                  | Web app memory resource requests                     | `100Mi`                         |
+| `webResources.limits.cpu`                       | Web app CPU resource limit                           | `200m`                          |
+| `webResources.limits.memory`                    | Web app memory resource limit                        | `500Mi`                         |
+| `embedAdmissionController`                      | Flag for enabling/disabling the admission controller | `true`                          |
+| `enableSchedulerPlugin`                         | Flag for enabling/disabling scheduler plugin mode    | `false`                         |
+| `operatorPlugins`                               | Scheduler operator plugins                           | `general`                       |
+| `nodeSelector`                                  | Scheduler deployment nodeSelector(s)                 | `{}`                            |
+| `tolerations`                                   | Scheduler deployment tolerations                     | `[]`                            |
+| `affinity`                                      | Scheduler deployment affinity                        | `{}`                            |
 
 These parameters can be passed in via helm's `--set` option, such as `--set embedAdmissionController=false`.
 

--- a/helm-charts/yunikorn/templates/admission-controller-deployment.yaml
+++ b/helm-charts/yunikorn/templates/admission-controller-deployment.yaml
@@ -26,7 +26,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.admissionControllerReplicaCount }}
+  replicas: {{ .Values.admissionController.replicaCount }}
   selector:
     matchLabels:
       app: yunikorn
@@ -40,18 +40,30 @@ spec:
         component: yunikorn-admission-controller
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ .Values.admissionControllerServiceAccount }}
+      serviceAccountName: {{ .Values.admissionController.serviceAccount }}
+      {{- with .Values.admissionController.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admissionController.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admissionController.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: yunikorn-admission-controller
-          image: "{{ .Values.admissionControllerImage.repository }}:{{ .Values.admissionControllerImage.tag }}"
-          imagePullPolicy: {{ .Values.admissionControllerImage.pullPolicy }}
+          image: "{{ .Values.admissionController.image.repository }}:{{ .Values.admissionController.image.tag }}"
+          imagePullPolicy: {{ .Values.admissionController.image.pullPolicy }}
           resources:
             requests:
-              cpu: 100m
-              memory: 500Mi
+              cpu: {{ .Values.admissionController.resources.requests.cpu }}
+              memory: {{ .Values.admissionController.resources.requests.memory }}
             limits:
-              cpu: 500m
-              memory: 500Mi
+              cpu: {{ .Values.admissionController.resources.limits.cpu }}
+              memory: {{ .Values.admissionController.resources.limits.memory }}
           volumeMounts:
             - name: admission-controller-secrets
               mountPath: /run/secrets/webhook
@@ -62,7 +74,7 @@ spec:
           - name: ADMISSION_CONTROLLER_SERVICE
             value: yunikorn-admission-controller-service
           - name: ADMISSION_CONTROLLER_NAMESPACE_BLACKLIST
-            value: "{{ .Values.admissionControllerNamespaceBlacklist }}"
+            value: "{{ .Values.admissionController.namespaceBlacklist }}"
           - name: SCHEDULER_SERVICE_ADDRESS
             value: "yunikorn-service:9080"
           - name: ENABLE_CONFIG_HOT_REFRESH

--- a/helm-charts/yunikorn/templates/admission-controller-rbac.yaml
+++ b/helm-charts/yunikorn/templates/admission-controller-rbac.yaml
@@ -19,7 +19,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.admissionControllerServiceAccount }}
+  name: {{ .Values.admissionController.serviceAccount }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
@@ -64,7 +64,7 @@ metadata:
     "helm.sh/hook-weight": "1"
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.admissionControllerServiceAccount }}
+    name: {{ .Values.admissionController.serviceAccount }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
@@ -80,7 +80,7 @@ metadata:
     "helm.sh/hook-weight": "1"
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.admissionControllerServiceAccount }}
+    name: {{ .Values.admissionController.serviceAccount }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role

--- a/helm-charts/yunikorn/templates/deployment.yaml
+++ b/helm-charts/yunikorn/templates/deployment.yaml
@@ -49,6 +49,14 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: yunikorn-scheduler-k8s
       {{- if .Values.enableSchedulerPlugin }}
@@ -94,11 +102,11 @@ spec:
               protocol: TCP
           resources:
             requests:
-              memory: "100Mi"
-              cpu: "100m"
+              memory: {{ .Values.webResources.requests.memory }}
+              cpu: {{ .Values.webResources.requests.cpu }}
             limits:
-              memory: "500Mi"
-              cpu: "200m"
+              memory: {{ .Values.webResources.limits.memory }}
+              cpu: {{ .Values.webResources.limits.cpu }}
       volumes:
         - name: config-volume
           configMap:

--- a/helm-charts/yunikorn/values.yaml
+++ b/helm-charts/yunikorn/values.yaml
@@ -18,7 +18,6 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
-admissionControllerReplicaCount: 1
 
 imagePullSecrets:
 
@@ -27,9 +26,6 @@ userLabelKey: "yunikorn.apache.org/username"
 operatorPlugins: "general"
 
 serviceAccount: yunikorn-admin
-admissionControllerServiceAccount: yunikorn-admission-controller
-
-admissionControllerNamespaceBlacklist: "^kube-system$"
 
 image:
   repository: apache/yunikorn
@@ -41,10 +37,28 @@ pluginImage:
   tag: scheduler-plugin-latest
   pullPolicy: Always
 
-admissionControllerImage:
-  repository: apache/yunikorn
-  tag: admission-latest
-  pullPolicy: Always
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+admissionController:
+  image:
+    repository: apache/yunikorn
+    tag: admission-latest
+    pullPolicy: Always
+  replicaCount: 1
+  serviceAccount: yunikorn-admission-controller
+  namespaceBlacklist: "^kube-system$"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 500Mi
+    limits:
+      cpu: 500m
+      memory: 500Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 webImage:
   repository: apache/yunikorn
@@ -63,6 +77,15 @@ resources:
   limits:
     cpu: 4
     memory: 2Gi
+
+webResources:
+  resources:
+    requests:
+      memory: "100Mi"
+      cpu: "100m"
+    limits:
+      memory: "500Mi"
+      cpu: "200m"
 
 # When this flag is true, the admission controller will be installed along with the scheduler.
 # When this flag is false, the admission controller will not be installed.


### PR DESCRIPTION
Issue: [YUNIKORN-1078](https://issues.apache.org/jira/browse/YUNIKORN-1078)

This PR add extra parameters for the helm's chart:
- `tolerations`
- `affinity`
- `webResources.requests.cpu`
- `webResources.requests.memory`
- `webResources.limits.cpu`
- `webResources.limits.memory`

and define all the admission controller's related parameters under the `admissionController` object:
- `admissionController.image.replicaCount`
- `admissionController.serviceAccount`
- `admissionController.image.repository`
- `admissionController.image.tag`
- `admissionController.image.pullPolicy`
- `admissionController.namespaceBlacklist`
- `admissionController.resources.requests.cpu`
- `admissionController.resources.requests.memory`
- `admissionController.resources.limits.cpu`
- `admissionController.resources.limits.memory`
- `admissionController.nodeSelector`
- `admissionController.tolerations`
- `admissionController.affinity`
