### PR TITLE
[YUNIKORN-1367] Don't mount configmap into scheduler pod

### DIFF
--- a/helm-charts/yunikorn/templates/deployment.yaml
+++ b/helm-charts/yunikorn/templates/deployment.yaml
@@ -96,9 +96,6 @@ spec:
             limits:
               cpu: {{ .Values.resources.limits.cpu }}
               memory: {{ .Values.resources.limits.memory }}
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/yunikorn/
         - name: yunikorn-scheduler-web
           image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
@@ -113,7 +110,3 @@ spec:
             limits:
               memory: {{ .Values.web.resources.limits.memory }}
               cpu: {{ .Values.web.resources.limits.cpu }}
-      volumes:
-        - name: config-volume
-          configMap:
-            name: yunikorn-configs


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/YUNIKORN-1367

Now that https://issues.apache.org/jira/browse/YUNIKORN-1365 has landed, we no longer need to mount the configmap into the scheduler pod as it is no longer used.

Testing:

Local installation of YuniKorn passes all e2e tests using this chart.