### PR TITLE
[YUNIKORN-3105] move release staging out of the tools directory

### DIFF
--- a/release-tools/build-image.py
+++ b/release-tools/build-image.py
@@ -75,7 +75,7 @@ def load_config():
         fail("load config: repository list not found")
     repo_list = data["repositories"]
 
-    staging_dir = os.path.join(os.path.dirname(tools_dir), "staging")
+    staging_dir = os.path.join(os.path.dirname(tools_dir), "build", "staging")
     release_base = os.path.join(staging_dir, release_package_name)
 
     print("release meta info:")

--- a/release-tools/build-release.py
+++ b/release-tools/build-release.py
@@ -62,7 +62,7 @@ def build_release(email_address):
     print(" - main version: %s" % version)
     print(" - release package name: %s" % release_package_name)
 
-    staging_dir = os.path.join(os.path.dirname(tools_dir), "staging")
+    staging_dir = os.path.join(os.path.dirname(tools_dir), "build", "staging")
     release_base = os.path.join(staging_dir, release_package_name)
     release_top_path = os.path.join(os.path.dirname(tools_dir), "release-top-level-artifacts")
     helm_chart_path = os.path.join(os.path.dirname(tools_dir), "helm-charts")


### PR DESCRIPTION
### What is this PR for?
Move the generated artifacts from release scripts to a new `build` directory like used in all other repos.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-3105

