### PR TITLE
[YUNIKORN-3212] auto update GOMEMLIMIT setting

### DIFF
--- a/helm-charts/yunikorn/README.md
+++ b/helm-charts/yunikorn/README.md
@@ -64,64 +64,64 @@ helm install yunikorn yunikorn/yunikorn
 ## Configuration
 The following table lists the configurable parameters of the YuniKorn chart and their default values:
 
-| Parameter                                       | Description                                                 | Default                         |
-| ----------------------------------------------- | ----------------------------------------------------------- | ------------------------------- |
-| `imagePullSecrets`                              | Docker repository secrets                                   | `[]`                            |
-| `serviceAccount`                                | Service account name                                        | `yunikorn-admin`                |
-| `hostNetwork`                                   | Whether scheduler should run in the host network            | `false`                         |
-| `image.repository`                              | Scheduler image repository                                  | `apache/yunikorn`               |
-| `image.tag`                                     | Scheduler image tag                                         | `scheduler-latest`              |
-| `image.pullPolicy`                              | Scheduler image pull policy                                 | `Always`                        |
-| `pluginImage.repository`                        | Scheduler plugin image repository                           | `apache/yunikorn`               |
-| `pluginImage.tag`                               | Scheduler plugin image tag                                  | `scheduler-plugin-latest`       |
-| `pluginImage.pullPolicy`                        | Scheduler plugin image pull policy                          | `Always`                        |
-| `podLabels`                                     | Scheduler pod labels                                        | `{}`                            |
-| `podAnnotations`                                | Scheduler pod annotations                                   | `{}`                            |
-| `admissionController.podLabels`                 | Admission controller pod labels                             | `{}`                            |
-| `admissionController.podAnnotations`            | Admission controller pod annotations                        | `{}`                            |
-| `admissionController.replicaCount`              | Admission controller replicas to be deployed                | `1`                             |
-| `admissionController.serviceAccount`            | Admission controller service account name                   | `yunikorn-admission-controller` |
-| `admissionController.image.repository`          | Admission controller image repository                       | `apache/yunikorn`               |
-| `admissionController.image.tag`                 | Admission controller image tag                              | `admission-latest`              |
-| `admissionController.image.pullPolicy`          | Admission controller image pull policy                      | `Always`                        |
-| `admissionController.hostNetwork`               | Whether admission controller should run in the host network | `true`                          |
-| `admissionController.resources.requests.cpu`    | Admission controller CPU resource requests                  | `100m`                          |
-| `admissionController.resources.requests.memory` | Admission controller memory resource requests               | `500Mi`                         |
-| `admissionController.resources.limits.cpu`      | Admission controller CPU resource limit                     | `500m`                          |
-| `admissionController.resources.limits.memory`   | Admission controller memory resource limit                  | `500Mi`                         |
-| `admissionController.goMemoryLimit`             | Admission controller memory limit (GOMEMLIMIT)              | `200MiB`                        |
-| `admissionController.goGC`                      | Admission controller GC threshold (GOGC)                    | `100`                           |
-| `admissionController.nodeSelector`              | Admission controller deployment nodeSelector(s)             | `{}`                            |
-| `admissionController.tolerations`               | Admission controller deployment tolerations                 | `[]`                            |
-| `admissionController.affinity`                  | Admission controller deployment affinity                    | `{}`                            |
-| `admissionController.service.type`              | Admission controller service type                           | `ClusterIP`                     |
-| `admissionController.priorityClassName`         | Admission controller pod priority                           | `""`                            |
-| `priorityClassName`                             | Scheduler pod priority                                      | `""`                            |
-| `service.type`                                  | Scheduler service type                                      | `ClusterIP`                     |
-| `service.port`                                  | Port of the scheduler service                               | `9080`                          |
-| `service.portWeb`                               | Port of the web application service                         | `9889`                          |
-| `resources.requests.cpu`                        | CPU resource requests                                       | `200m`                          |
-| `resources.requests.memory`                     | Memory resource requests                                    | `1Gi`                           |
-| `resources.limits.cpu`                          | CPU resource limit                                          | `4`                             |
-| `resources.limits.memory`                       | Memory resource limit                                       | `2Gi`                           |
-| `goMemoryLimit`                                 | Memory limit (GOMEMLIMIT)                                   | `1536MiB`                       |
-| `goGC`                                          | GC threshold (GOGC)                                         | `100`                           |
-| `web.image.repository`                          | Web app image repository                                    | `apache/yunikorn`               |
-| `web.image.tag`                                 | Web app image tag                                           | `web-latest`                    |
-| `web.image.pullPolicy`                          | Web app image pull policy                                   | `Always`                        |
-| `web.resources.requests.cpu`                    | Web app CPU resource requests                               | `100m`                          |
-| `web.resources.requests.memory`                 | Web app memory resource requests                            | `100Mi`                         |
-| `web.resources.limits.cpu`                      | Web app CPU resource limit                                  | `200m`                          |
-| `web.resources.limits.memory`                   | Web app memory resource limit                               | `500Mi`                         |
-| `web.goMemoryLimit`                             | Web app memory limit (GOMEMLIMIT)                           | `200MiB`                        |
-| `web.goGC`                                      | Web app GC threshold (GOGC)                                 | `100`                           |
-| `embedAdmissionController`                      | Flag for enabling/disabling the admission controller        | `true`                          |
-| `enableSchedulerPlugin`                         | Flag for enabling/disabling scheduler plugin mode           | `false`                         |
-| `enableWebService`                              | Flag for enabling/disabling web service                     | `true`                          |
-| `nodeSelector`                                  | Scheduler deployment nodeSelector(s)                        | `{}`                            |
-| `tolerations`                                   | Scheduler deployment tolerations                            | `[]`                            |
-| `affinity`                                      | Scheduler deployment affinity                               | `{}`                            |
-| `yunikornDefaults`                              | Data for the `yunikorn-defaults` ConfigMap                  | `{}`                            |
+| Parameter                                       | Description                                                                                           | Default                         |
+|-------------------------------------------------|-------------------------------------------------------------------------------------------------------|---------------------------------|
+| `imagePullSecrets`                              | Docker repository secrets                                                                             | `[]`                            |
+| `serviceAccount`                                | Service account name                                                                                  | `yunikorn-admin`                |
+| `hostNetwork`                                   | Whether scheduler should run in the host network                                                      | `false`                         |
+| `image.repository`                              | Scheduler image repository                                                                            | `apache/yunikorn`               |
+| `image.tag`                                     | Scheduler image tag                                                                                   | `scheduler-latest`              |
+| `image.pullPolicy`                              | Scheduler image pull policy                                                                           | `Always`                        |
+| `pluginImage.repository`                        | Scheduler plugin image repository                                                                     | `apache/yunikorn`               |
+| `pluginImage.tag`                               | Scheduler plugin image tag                                                                            | `scheduler-plugin-latest`       |
+| `pluginImage.pullPolicy`                        | Scheduler plugin image pull policy                                                                    | `Always`                        |
+| `podLabels`                                     | Scheduler pod labels                                                                                  | `{}`                            |
+| `podAnnotations`                                | Scheduler pod annotations                                                                             | `{}`                            |
+| `admissionController.podLabels`                 | Admission controller pod labels                                                                       | `{}`                            |
+| `admissionController.podAnnotations`            | Admission controller pod annotations                                                                  | `{}`                            |
+| `admissionController.replicaCount`              | Admission controller replicas to be deployed                                                          | `1`                             |
+| `admissionController.serviceAccount`            | Admission controller service account name                                                             | `yunikorn-admission-controller` |
+| `admissionController.image.repository`          | Admission controller image repository                                                                 | `apache/yunikorn`               |
+| `admissionController.image.tag`                 | Admission controller image tag                                                                        | `admission-latest`              |
+| `admissionController.image.pullPolicy`          | Admission controller image pull policy                                                                | `Always`                        |
+| `admissionController.hostNetwork`               | Whether admission controller should run in the host network                                           | `true`                          |
+| `admissionController.resources.requests.cpu`    | Admission controller CPU resource requests                                                            | `100m`                          |
+| `admissionController.resources.requests.memory` | Admission controller memory resource requests                                                         | `500Mi`                         |
+| `admissionController.resources.limits.cpu`      | Admission controller CPU resource limit                                                               | `500m`                          |
+| `admissionController.resources.limits.memory`   | Admission controller memory resource limit                                                            | `500Mi`                         |
+| `admissionController.goMemoryLimitPercentage`   | Percentage to calculate the GOMEMLIMIT value with based on the container's `resources.limits.memory`  | `60`                            |
+| `admissionController.goGC`                      | Admission controller GC threshold (GOGC)                                                              | `100`                           |
+| `admissionController.nodeSelector`              | Admission controller deployment nodeSelector(s)                                                       | `{}`                            |
+| `admissionController.tolerations`               | Admission controller deployment tolerations                                                           | `[]`                            |
+| `admissionController.affinity`                  | Admission controller deployment affinity                                                              | `{}`                            |
+| `admissionController.service.type`              | Admission controller service type                                                                     | `ClusterIP`                     |
+| `admissionController.priorityClassName`         | Admission controller pod priority                                                                     | `""`                            |
+| `priorityClassName`                             | Scheduler pod priority                                                                                | `""`                            |
+| `service.type`                                  | Scheduler service type                                                                                | `ClusterIP`                     |
+| `service.port`                                  | Port of the scheduler service                                                                         | `9080`                          |
+| `service.portWeb`                               | Port of the web application service                                                                   | `9889`                          |
+| `resources.requests.cpu`                        | CPU resource requests                                                                                 | `200m`                          |
+| `resources.requests.memory`                     | Memory resource requests                                                                              | `1Gi`                           |
+| `resources.limits.cpu`                          | CPU resource limit                                                                                    | `4`                             |
+| `resources.limits.memory`                       | Memory resource limit                                                                                 | `2Gi`                           |
+| `goMemoryLimitPercentage`                       | Percentage to calculate the GOMEMLIMIT value with based on the container's `resources.limits.memory`  | `80`                            |
+| `goGC`                                          | GC threshold (GOGC)                                                                                   | `100`                           |
+| `web.image.repository`                          | Web app image repository                                                                              | `apache/yunikorn`               |
+| `web.image.tag`                                 | Web app image tag                                                                                     | `web-latest`                    |
+| `web.image.pullPolicy`                          | Web app image pull policy                                                                             | `Always`                        |
+| `web.resources.requests.cpu`                    | Web app CPU resource requests                                                                         | `100m`                          |
+| `web.resources.requests.memory`                 | Web app memory resource requests                                                                      | `100Mi`                         |
+| `web.resources.limits.cpu`                      | Web app CPU resource limit                                                                            | `200m`                          |
+| `web.resources.limits.memory`                   | Web app memory resource limit                                                                         | `500Mi`                         |
+| `web.goMemoryLimitPercentage`                   | Percentage to calculate the GOMEMLIMIT value with based on the container's `resources.limits.memory`  | `60`                            |
+| `web.goGC`                                      | Web app GC threshold (GOGC)                                                                           | `100`                           |
+| `embedAdmissionController`                      | Flag for enabling/disabling the admission controller                                                  | `true`                          |
+| `enableSchedulerPlugin`                         | Flag for enabling/disabling scheduler plugin mode                                                     | `false`                         |
+| `enableWebService`                              | Flag for enabling/disabling web service                                                               | `true`                          |
+| `nodeSelector`                                  | Scheduler deployment nodeSelector(s)                                                                  | `{}`                            |
+| `tolerations`                                   | Scheduler deployment tolerations                                                                      | `[]`                            |
+| `affinity`                                      | Scheduler deployment affinity                                                                         | `{}`                            |
+| `yunikornDefaults`                              | Data for the `yunikorn-defaults` ConfigMap                                                            | `{}`                            |
 
 
 These parameters can be passed in via helm's `--set` and `--values (-f)` options, such as `--set resources.requests.cpu=2000m` or `-f myvalues.yaml`.
@@ -142,3 +142,12 @@ The following configuration parameters are deprecated and will be ignored in a f
 | `configuration`                         | YAML-formatted queue configuration                  | `queues.yaml` ConfigMap entry                                     |
 
 Currently, if both the deprecated parameter and the replacement ConfigMap entry are specified, the ConfigMap entry will take precedence.
+
+The following settings have been deprecated. The new percentage based settings have precedence over the deprecated settings.
+The deprecated settings will only be used as a fallback if the new percentage based settings are not present.
+
+| Parameter                           | Description                                    | Replacement                                   |
+|-------------------------------------|------------------------------------------------|-----------------------------------------------|
+| `goMemoryLimit`                     | Memory limit (GOMEMLIMIT)                      | `goMemoryLimitPercentage`                     |
+| `web.goMemoryLimit`                 | Web app memory limit (GOMEMLIMIT)              | `web.goMemoryLimitPercentage`                 |
+| `admissionController.goMemoryLimit` | Admission controller memory limit (GOMEMLIMIT) | `admissionController.goMemoryLimitPercentage` |

--- a/helm-charts/yunikorn/templates/_helpers.tpl
+++ b/helm-charts/yunikorn/templates/_helpers.tpl
@@ -46,3 +46,33 @@ Create chart name and version as used by the chart label.
 {{- define "yunikorn.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Convert the Kubernetes memory string (e.g. 1500Mi) into bytes: suffix dicts merged, then value × multiplier (Ki..Ei use 0x1pN).
+*/}}
+{{- define "yunikorn.resource-quantity" -}}
+    {{- $value := . -}}
+    {{- $unit := 1.0 -}}
+    {{- $mem := . | toString | trim -}}
+    {{- if typeIs "string" . -}}
+        {{- $base2 := dict "Ki" 0x1p10 "Mi" 0x1p20 "Gi" 0x1p30 "Ti" 0x1p40 "Pi" 0x1p50 "Ei" 0x1p60 -}}
+        {{- $base10 := dict "m" 1e-3 "k" 1e3 "M" 1e6 "G" 1e9 "T" 1e12 "P" 1e15 "E" 1e18 -}}
+        {{- range $k, $v := merge $base2 $base10 -}}
+            {{- if hasSuffix $k $mem -}}
+                {{- $value = trimSuffix $k $mem -}}
+                {{- $unit = $v -}}
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
+    {{- mulf (float64 $value) $unit -}}
+{{- end -}}
+
+{{/*
+Soft memory limit: limits.memory (bytes) × (goMemoryLimitPercentage/100), rounded up (ceil).
+*/}}
+{{- define "yunikorn.goMemLimit" -}}
+    {{- $multi := divf (float64 .goMemoryLimitPercentage) 100.0 -}}
+    {{- with .resources.limits.memory -}}
+        {{- include "yunikorn.resource-quantity" . | float64 | mulf $multi | ceil | int -}}
+    {{- end }}
+{{- end -}}

--- a/helm-charts/yunikorn/templates/admission-controller-deployment.yaml
+++ b/helm-charts/yunikorn/templates/admission-controller-deployment.yaml
@@ -105,9 +105,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- with include "yunikorn.goMemLimit" .Values.admissionController }}
             - name: GOMEMLIMIT
+            {{- if .Values.admissionController.goMemoryLimitPercentage }}
+            {{- with include "yunikorn.goMemLimit" .Values.admissionController }}
               value: {{ quote . }}
+            {{- end }}
+            {{- else }}
+              value: "{{ .Values.admissionController.goMemoryLimit }}"
             {{- end }}
             - name: GOGC
               value: "{{ .Values.admissionController.goGC }}"

--- a/helm-charts/yunikorn/templates/admission-controller-deployment.yaml
+++ b/helm-charts/yunikorn/templates/admission-controller-deployment.yaml
@@ -105,8 +105,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- with include "yunikorn.goMemLimit" .Values.admissionController }}
             - name: GOMEMLIMIT
-              value: "{{ .Values.admissionController.goMemoryLimit }}"
+              value: {{ quote . }}
+            {{- end }}
             - name: GOGC
               value: "{{ .Values.admissionController.goGC }}"
           ports:

--- a/helm-charts/yunikorn/templates/deployment.yaml
+++ b/helm-charts/yunikorn/templates/deployment.yaml
@@ -97,10 +97,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- with include "yunikorn.goMemLimit" .Values }}
             - name: GOMEMLIMIT
+              {{- if .Values.goMemoryLimitPercentage }}
+              {{- with include "yunikorn.goMemLimit" .Values }}
               value: {{ quote . }}
-            {{- end }}
+              {{- end }}
+              {{- else }}
+              value: "{{ .Values.goMemoryLimit }}"
+              {{- end }}
             - name: GOGC
               value: "{{ .Values.goGC }}"
           resources:
@@ -118,10 +122,14 @@ spec:
               containerPort: {{ .Values.service.portWeb }}
               protocol: TCP
           env:
-            {{- with include "yunikorn.goMemLimit" .Values.web }}
             - name: GOMEMLIMIT
+              {{- if .Values.web.goMemoryLimitPercentage }}
+              {{- with include "yunikorn.goMemLimit" .Values.web }}
               value: {{ quote . }}
-            {{- end }}
+              {{- end }}
+              {{- else }}
+              value: "{{ .Values.web.goMemoryLimit }}"
+              {{- end }}
             - name: GOGC
               value: "{{ .Values.web.goGC }}"
           resources:

--- a/helm-charts/yunikorn/templates/deployment.yaml
+++ b/helm-charts/yunikorn/templates/deployment.yaml
@@ -97,8 +97,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- with include "yunikorn.goMemLimit" .Values }}
             - name: GOMEMLIMIT
-              value: "{{ .Values.goMemoryLimit }}"
+              value: {{ quote . }}
+            {{- end }}
             - name: GOGC
               value: "{{ .Values.goGC }}"
           resources:
@@ -116,8 +118,10 @@ spec:
               containerPort: {{ .Values.service.portWeb }}
               protocol: TCP
           env:
+            {{- with include "yunikorn.goMemLimit" .Values.web }}
             - name: GOMEMLIMIT
-              value: "{{ .Values.web.goMemoryLimit }}"
+              value: {{ quote . }}
+            {{- end }}
             - name: GOGC
               value: "{{ .Values.web.goGC }}"
           resources:

--- a/helm-charts/yunikorn/values.yaml
+++ b/helm-charts/yunikorn/values.yaml
@@ -57,7 +57,7 @@ admissionController:
     limits:
       cpu: 500m
       memory: 500Mi
-  goMemoryLimit: 200MiB
+  goMemoryLimitPercentage: 60
   goGC: 100
   nodeSelector: {}
   tolerations: []
@@ -83,7 +83,7 @@ web:
     limits:
       cpu: 200m
       memory: 500Mi
-  goMemoryLimit: 200MiB
+  goMemoryLimitPercentage: 60
   goGC: 100
 
 service:
@@ -109,9 +109,9 @@ resources:
     cpu: 4
     memory: 2Gi
 
-# Go memory limit (GOMEMLIMIT) for the scheduler. This should be updated in tandem with
-# resources.limits.memory to avoid OOMKilled scenarios.
-goMemoryLimit: 1536MiB
+# Percentage of the real memory limit of the container to which the GOMEMLIMIT variable is set
+# GOMEMLIMIT variable sets a soft memory limit for the runtime to use in GC runs.
+goMemoryLimitPercentage: 80
 
 # Go garbage-collection threshold (GOGC) as a percentage of freshly allocated data to
 # live data remaining after the previous GC.


### PR DESCRIPTION
### What is this PR for?
Change the helm chart to calculate the GOMEMLIMIT value based on the memory limit of the container. The goMemoryLimit value is changed to goMemoryLimitPercentage.

Defaults:
* 80% for the scheduler container
* 60% for the admission controller and web container

The defaults are the existing fixed values converted into percentages.

### What type of PR is it?
* [X] - Improvement

### What is the Jira issue?
* [YUNIKORN-3212](https://issues.apache.org/jira/browse/YUNIKORN-3212)

### How should this be tested?
cd helm-charts/yunikorn
helm template -f values.yaml .

Check the output of the generated files via: `grep -C 3 GOMEMLIMIT` to see the specific values

### Questions:
* [X] - It needs documentation.
