### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -37,13 +37,12 @@ github:
     projects: false
 
   rulesets:
-    - name: "Default Branch Protection"
+    - name: "Branch Protection"
       type: branch
       branches:
         includes:
           - "~DEFAULT_BRANCH"
-          - "release/*"
-          - "rel/*"
+          - "branch-*"
         excludes: []
       bypass_teams:
         - root

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,15 +29,28 @@ github:
     - kubernetes
   enabled_merge_buttons:
     squash: true
-    merge:  false
+    merge: false
     rebase: false
   features:
-    wiki:     false
-    issues:   false
+    wiki: false
+    issues: false
     projects: false
 
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
 notifications:
-  commits:      issues@yunikorn.apache.org
-  issues:       reviews@yunikorn.apache.org
+  commits: issues@yunikorn.apache.org
+  issues: reviews@yunikorn.apache.org
   pullrequests: reviews@yunikorn.apache.org
   jira_options: link label


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
