### PR TITLE
[YUNIKORN-3253] Remove deprecated helm values

### DIFF
--- a/helm-charts/yunikorn/README.md
+++ b/helm-charts/yunikorn/README.md
@@ -54,6 +54,7 @@ YuniKorn can be deployed with [helm-charts](https://artifacthub.io/packages/helm
 | 1.32.x              |    √     |
 | 1.33.x              |    √     |
 | 1.34.x              |    √     |
+| 1.35.x              |    √     |
 
 ## Installing the chart
 ```
@@ -125,20 +126,6 @@ These parameters can be passed in via helm's `--set` and `--values (-f)` options
 In addition to these parameters, YuniKorn supports reading most of its runtime configuration directly from two ConfigMaps in the installed namespace: `yunikorn-defaults` and `yunikorn-configs`. The `yunikorn-defaults` ConfigMap is rendered by Helm based on the contents of the `yunikornDefaults` parameter. The `yunikorn-configs` ConfigMap is entirely ignored by Helm, and can be populated (or not) using external mechanisms. At runtime, YuniKorn will evaluate both ConfigMaps, using the contents of `yunikorn-configs` as an override to `yunikorn-defaults`.
 
 ## Deprecated Configuration
-The following configuration parameters are deprecated and will be ignored in a future release of YuniKorn:
-
-| Parameter                               | Description                                         | Replacement                                                       |
-|-----------------------------------------|-----------------------------------------------------|-------------------------------------------------------------------|
-| `operatorPlugins`                       | Scheduler operator plugins                          | `service.operatorPlugins` ConfigMap entry                         |
-| `placeholderImage`                      | Docker image of the placeholder pods                | `service.placeholderImage` ConfigMap entry                        |
-| `admissionController.processNamespaces` | List of namespace regexes to process (empty=ALL)    | `admissionController.filtering.processNamespaces` ConfigMap entry |
-| `admissionController.bypassNamespaces`  | List of namespace regexes to bypass (empty=NONE)    | `admissionController.filtering.bypassNamespaces` ConfigMap entry  |
-| `admissionController.labelNamespaces`   | List of namespace regexes to label (empty=ALL)      | `admissionController.filtering.labelNamespaces` ConfigMap entry   |
-| `admissionController.noLabelNamespaces` | List of namespace regexes not to label (empty=NONE) | `admissionController.filtering.noLabelNamespaces` ConfigMap entry |
-| `configuration`                         | YAML-formatted queue configuration                  | `queues.yaml` ConfigMap entry                                     |
-
-Currently, if both the deprecated parameter and the replacement ConfigMap entry are specified, the ConfigMap entry will take precedence.
-
 The following settings have been deprecated. The new percentage based settings have precedence over the deprecated settings.
 The deprecated settings will only be used as a fallback if the new percentage based settings are not present.
 

--- a/helm-charts/yunikorn/templates/yunikorn-defaults.yaml
+++ b/helm-charts/yunikorn/templates/yunikorn-defaults.yaml
@@ -26,43 +26,8 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
 data:
-{{- if .Values.operatorPlugins }}
-{{- if not (get .Values.yunikornDefaults "operatorPlugins") }}
-  service.operatorPlugins: "{{.Values.operatorPlugins}}"
-{{- end }}
-{{- end }}
-{{- if .Values.placeHolderImage }}
-{{- if not (get .Values.yunikornDefaults "service.placeholderImage") }}
-  service.placeholderImage: "{{ .Values.placeHolderImage }}"
-{{- end }}
-{{- end }}
-{{- if .Values.admissionController.processNamespaces }}
-{{- if not (get .Values.yunikornDefaults "admissionController.filtering.processNamespaces") }}
-  admissionController.filtering.processNamespaces: "{{ .Values.admissionController.processNamespaces }}"
-{{- end }}
-{{- end }}
-{{- if .Values.admissionController.bypassNamespaces }}
-{{- if not (get .Values.yunikornDefaults "admissionController.filtering.bypassNamespaces") }}
-  admissionController.filtering.bypassNamespaces: "{{ .Values.admissionController.bypassNamespaces }}"
-{{- end }}
-{{- end }}
-{{- if .Values.admissionController.labelNamespaces }}
-{{- if not (get .Values.yunikornDefaults "admissionController.filtering.labelNamespaces") }}
-  admissionController.filtering.labelNamespaces: "{{ .Values.admissionController.labelNamespaces }}"
-{{- end }}
-{{- end }}
-{{- if .Values.admissionController.noLabelNamespaces }}
-{{- if not (get .Values.yunikornDefaults "admissionController.filtering.noLabelNamespaces") }}
-  admissionController.filtering.noLabelNamespaces: "{{ .Values.admissionController.noLabelNamespaces }}"
-{{- end }}
-{{- end }}
-{{- if .Values.configuration }}
-{{- if not (get .Values.yunikornDefaults "queues.yaml") }}
-  queues.yaml: {{quote .Values.configuration}}
-{{- end }}
-{{- end }}
 {{- if .Values.yunikornDefaults }}
 {{- range $key, $val := .Values.yunikornDefaults }}
-  "{{ $key }}": {{quote $val }}
+  "{{ $key }}": {{ quote $val }}
 {{- end }}
 {{- end }}

--- a/helm-charts/yunikorn/values.yaml
+++ b/helm-charts/yunikorn/values.yaml
@@ -32,10 +32,6 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
-configuration: null    # deprecated; use queues.yaml in yunikornDefaults
-operatorPlugins: null  # deprecated; use service.operatorPlugins in yunikornDefaults
-placeHolderImage: null # deprecated; use service.placeholderImage in yunikornDefaults
-
 admissionController:
   priorityClassName: ""
   image:
@@ -59,10 +55,6 @@ admissionController:
   affinity: {}
   service:
     type: ClusterIP
-  processNamespaces: null # deprecated; use admissionController.filtering.processNamespaces in yunikornDefaults
-  bypassNamespaces: null  # deprecated; use admissionController.filtering.bypassNamespaces in yunikornDefaults
-  labelNamespaces: null   # deprecated; use admissionController.filtering.labelNamespaces in yunikornDefaults
-  noLabelNamespaces: null # deprecated; use admissionController.filtering.noLabelNamespaces in yunikornDefaults
   podLabels: {}
   podAnnotations: {}
 
@@ -120,7 +112,12 @@ goGC: 100
 #   service.placeholderRunAsUser: 65534
 #   service.placeholderRunAsGroup: 65534
 #   service.placeholderFsGroup: 65534
+#   admissionController.filtering.processNamespaces: "example"
+#   admissionController.filtering.bypassNamespaces: "kube-system"
+#   admissionController.filtering.labelNamespaces
+#   admissionController.filtering.noLabelNamespaces
 yunikornDefaults: {}
+
 # When this flag is true, the admission controller will be installed along with the scheduler.
 # When this flag is false, the admission controller will not be installed.
 # Once the admission controller is installed, all traffic will be routing to yunikorn.


### PR DESCRIPTION
### What is this PR for?
Remove the deprecated settings:
* operatorPlugins
* placeholderImage
* admissionController.processNamespaces
* admissionController.bypassNamespaces
* admissionController.labelNamespaces
* admissionController.noLabelNamespaces
* configuration

All settings have equivalent yunikornDefaults options in the values.yaml.

This change will be release noted

### What type of PR is it?
* [X] - Improvement

### What is the Jira issue?
* [YUNIKORN-3253](https://issues.apache.org/jira/browse/YUNIKORN-3253)

### How should this be tested?
helm template before and after the change renders the same yunikorn-defaults configmap yaml