### PR TITLE
[YUNIKORN-3287] Support Gateway API HTTPRoute in Helm chart

### DIFF
--- a/helm-charts/yunikorn/README.md
+++ b/helm-charts/yunikorn/README.md
@@ -115,6 +115,10 @@ The following table lists the configurable parameters of the YuniKorn chart and 
 | `web.goGC`                                      | Web app GC threshold (GOGC)                                                                           | `100`                           |
 | `embedAdmissionController`                      | Flag for enabling/disabling the admission controller                                                  | `true`                          |
 | `enableWebService`                              | Flag for enabling/disabling web service                                                               | `true`                          |
+| `httpRoute.enabled`                             | Flag for enabling/disabling HTTPRoute resource for Gateway API                                        | `false`                         |
+| `httpRoute.annotations`                         | Annotations for the HTTPRoute resource                                                                | `{}`                            |
+| `httpRoute.parentRefs`                          | Parent Gateway references for the HTTPRoute                                                           | `[]`                            |
+| `httpRoute.hostnames`                           | Hostnames to match for the HTTPRoute                                                                  | `[]`                            |
 | `nodeSelector`                                  | Scheduler deployment nodeSelector(s)                                                                  | `{}`                            |
 | `tolerations`                                   | Scheduler deployment tolerations                                                                      | `[]`                            |
 | `affinity`                                      | Scheduler deployment affinity                                                                         | `{}`                            |

--- a/helm-charts/yunikorn/templates/httproute.yaml
+++ b/helm-charts/yunikorn/templates/httproute.yaml
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if and .Values.httpRoute.enabled .Values.enableWebService }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: yunikorn-httproute
+  labels:
+    app: yunikorn
+    chart: {{ include "yunikorn.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.httpRoute.rules }}
+      {{- toYaml .Values.httpRoute.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: yunikorn-service
+          port: {{ .Values.service.portWeb }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/helm-charts/yunikorn/values.yaml
+++ b/helm-charts/yunikorn/values.yaml
@@ -88,6 +88,29 @@ ingress:
   pathType: Prefix
   tls: []
 
+# HTTPRoute configuration to expose the YuniKorn UI through the Gateway API.
+# This requires the Gateway API CRDs to be installed on your cluster.
+#
+# When enabled is true, the HTTPRoute resource will be deployed.
+# Note: You must configure `parentRefs` to attach the route to an existing Gateway.
+httpRoute:
+  enabled: false
+  annotations: {}
+
+  # At least one parentRef is required to attach the route to a Gateway.
+  parentRefs: []
+  #  - group: gateway.networking.k8s.io
+  #    kind: Gateway
+  #    name: yunikorn-gateway
+  #    namespace: yunikorn
+
+  # Hostnames to match for the HTTPRoute.
+  hostnames: []
+  #  - chart-example.local
+
+  # Custom routing rules. If empty, a default rule mapping to the UI service is used.
+  # rules: []
+
 resources:
   requests:
     cpu: 200m


### PR DESCRIPTION
### Description
This PR introduces first-class support for the Kubernetes Gateway API (`HTTPRoute`) in the YuniKorn Helm chart, addressing [YUNIKORN-3287].

Key additions:
1. **HTTPRoute Template**: Added `httproute.yaml` to deploy an `HTTPRoute` resource, enabling modern ingress routing to the YuniKorn Web UI.

All features are disabled by default to ensure backward compatibility.

Generated by Antigravity IDE.

### Type of change
- [x] Feature

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3287

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
- [x] The PR includes the phrase "Generated by Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

### How has this been tested?
- **Helm Template Validation**: Verified `helm template` generates correct `HTTPRoute` and custom resources based on `values.yaml` inputs.
- **Minikube End-to-End Test**:
  - Installed Gateway API CRDs (`gateway.networking.k8s.io`) and an NGINX Gateway on Minikube.
  - Deployed YuniKorn via `helm upgrade` with `httpRoute.enabled=true` and custom `hostnames`.
  - Used `kubectl port-forward` to the Gateway service and verified that `curl` to the YuniKorn Web UI (`/`) and REST API (`/ws/v1/clusters`) successfully returned HTTP 200, and rejected invalid hostnames with HTTP 404.


### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.
