### PR TITLE
[YUNIKORN-3328] Fix repository order in release-configs.json

### DIFF
--- a/release-tools/release-configs.json
+++ b/release-tools/release-configs.json
@@ -4,24 +4,27 @@
   },
   "repositories": [
     {
-      "name": "yunikorn-core",
-      "alias": "core",
-      "description": "scheduler core library",
-      "tag": "v1.6.1",
-      "repository": "https://github.com/apache/yunikorn-core"
-    }, {
-      "name": "yunikorn-k8shim",
-      "alias": "k8shim",
-      "description": "the scheduler shim for K8s",
-      "tag": "v1.6.1",
-      "repository": "https://github.com/apache/yunikorn-k8shim"
-    }, {
       "name": "yunikorn-scheduler-interface",
       "alias": "scheduler-interface",
       "description": "the common scheduler interface that defines common messages and protocols",
       "tag": "v1.6.1",
       "repository": "https://github.com/apache/yunikorn-scheduler-interface"
-    }, {
+    },
+    {
+      "name": "yunikorn-core",
+      "alias": "core",
+      "description": "scheduler core library",
+      "tag": "v1.6.1",
+      "repository": "https://github.com/apache/yunikorn-core"
+    },
+    {
+      "name": "yunikorn-k8shim",
+      "alias": "k8shim",
+      "description": "the scheduler shim for K8s",
+      "tag": "v1.6.1",
+      "repository": "https://github.com/apache/yunikorn-k8shim"
+    },
+    {
       "name": "yunikorn-web",
       "alias": "web",
       "description": "the scheduler web UI",


### PR DESCRIPTION
### Description
Fix the repository order in `release-configs.json` to correctly resolve dependencies during the release build process. The `scheduler-interface` must be loaded first because `core` and `k8shim` depend on it. This fixes the dependency update failure during `build-release.py`.


### Type of change
Please delete options that are not relevant.

- [X] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3328

- [X] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
Manual Verification: Ran `build-release.py` locally and verified that the `go mod tidy` failure on `core` dependency updates is resolved and the script successfully proceeds to build the helm charts and tarballs.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A
