### PR TITLE
[YUNIKORN-3327] Replace deprecated distutils with shutil in release script

### DIFF
--- a/release-tools/build-release.py
+++ b/release-tools/build-release.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import distutils.dir_util
 import getopt
 import hashlib
 import json
@@ -175,7 +174,7 @@ def setup_base_dir(release_top_path, helm_path, base_path, version):
 def copy_helm_charts(helm_path, base_path, version):
     print("helm patch: %s, base path: %s" % (helm_path, base_path))
     release_helm_path = os.path.join(base_path, "helm-charts")
-    distutils.dir_util.copy_tree(helm_path, release_helm_path)
+    shutil.copytree(helm_path, release_helm_path)
     # rename the version in the helm charts to the actual version
     yunikorn_chart_path = os.path.join(release_helm_path, "yunikorn")
     replace(os.path.join(yunikorn_chart_path, "values.yaml"), '(tag: .*-)(latest)', '\\g<1>' + version)


### PR DESCRIPTION
### Description
The `distutils` package is deprecated (PEP 632) and completely removed in Python 3.12. 
This updates `release-tools/build-release.py` to use the standard library `shutil.copytree` instead of `distutils.dir_util.copy_tree`, ensuring compatibility with modern Python environments. 


### Type of change
Please delete options that are not relevant.

- [X] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3327
- [X] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
Can be verified across different Python versions using `uv` (ensure `build/staging` is removed first):
**Python 3.12 (Verify fix & compatibility):**
```bash
uv run --python 3.12 --with GitPython python release-tools/build-release.py
```
**Python 3.10 (Verify warnings are resolved):**
```bash
SETUPTOOLS_USE_DISTUTILS=stdlib uv run --python 3.10 --with GitPython python -W default release-tools/build-release.py
```

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A
