### PR TITLE
[YUNIKORN-3340] use reproducible build in image release

### DIFF
--- a/release-tools/build-image.py
+++ b/release-tools/build-image.py
@@ -196,10 +196,11 @@ def build_manifest(manifest, version):
 def build_image(base_dir, image, arch, version):
     cmd = get_cmd("make")
     my_env = os.environ.copy()
-    my_env["QUIET"] = "--quiet"      # stop image build from being chatty
-    my_env["VERSION"] = version      # force version, just be safe
-    my_env["HOST_ARCH"] = arch       # the architecture override
-    my_env["REGISTRY"] = repository  # repository override (test only)
+    my_env["QUIET"] = "--quiet"          # stop image build from being chatty
+    my_env["VERSION"] = version          # force version, just be safe
+    my_env["HOST_ARCH"] = arch           # the architecture override
+    my_env["REPRODUCIBLE_BUILDS"] = "1"  # always use reproducible builds
+    my_env["REGISTRY"] = repository      # repository override (test only)
     command = [cmd, "clean", image]
     # build the image using make
     retcode = subprocess.call(command, cwd=base_dir, env=my_env, stdout=subprocess.DEVNULL)


### PR DESCRIPTION
### Description
Force REPRODUCIBLE_BUILDS=1 for images build as part of the release process.

### Type of change
- [X] Improvement

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3340

- [X] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.

### Questions:
- [X] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
